### PR TITLE
Add support for ROI conversion

### DIFF
--- a/src/napari_imagej/_function.py
+++ b/src/napari_imagej/_function.py
@@ -39,8 +39,6 @@ config.add_repositories(
     {"scijava.public": "https://maven.scijava.org/content/groups/public"}
 )
 config.endpoints.append("io.scif:scifio:0.43.1")
-# Used for Box ROI conversion
-config.endpoints.append("mpicbg:mpicbg:1.4.2")
 
 # Initialize ImageJ
 logger.debug("Initializing ImageJ2")

--- a/src/napari_imagej/_function.py
+++ b/src/napari_imagej/_function.py
@@ -39,6 +39,8 @@ config.add_repositories(
     {"scijava.public": "https://maven.scijava.org/content/groups/public"}
 )
 config.endpoints.append("io.scif:scifio:0.43.1")
+# Used for Box ROI conversion
+config.endpoints.append("mpicbg:mpicbg:1.4.2")
 
 # Initialize ImageJ
 logger.debug("Initializing ImageJ2")

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -260,11 +260,11 @@ def _napari_to_java_converters(ij) -> List[Converter]:
     ]
 
 
-def _java_to_napari_converters() -> List[Converter]:
+def _java_to_napari_converters(ij) -> List[Converter]:
     return [
         Converter(
             predicate=lambda obj: isinstance(obj, ImgLabeling),
-            converter=_imglabeling_to_layer,
+            converter=lambda obj: _imglabeling_to_layer(ij, obj),
             priority=Priority.VERY_HIGH
         ),
         Converter(
@@ -382,5 +382,5 @@ def init_napari_converters(ij):
         add_java_converter(converter)
 
     # Add Java -> napari converters
-    for converter in _java_to_napari_converters():
+    for converter in _java_to_napari_converters(ij):
         add_py_converter(converter)

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -62,13 +62,14 @@ def _ellipse_layer_to_mask(pts):
 
 
 def _ellipse_mask_to_data(mask):
+    # Make data array
+    data = np.zeros((2, mask.numDimensions()))
+    # Write center into the first column
     center = mask.center().positionAsDoubleArray()
-    radii = mask.minAsDoubleArray()
-    for i in range(radii.length):
-        radii[i] = mask.semiAxisLength(i)
-    data = np.zeros((2, center.length))
     data[0, :] = center[:] # Slice needed for JArray
-    data[1, :] = radii[:] # Slice needed for JArray
+    # Write radii into the second column
+    for i in range(data.shape[1]):
+        data[1, i] = mask.semiAxisLength(i)
     return data
 
 

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -346,11 +346,6 @@ def init_napari_converters(ij):
     global DefaultWritableLine
     global DefaultWritablePolyline
     global RealPoint
-    global Point
-    global PointMatch
-    global RigidModel2D
-    global AffineTransform
-    global RealViews
 
     Double = jimport(
         'java.lang.Double'
@@ -402,21 +397,6 @@ def init_napari_converters(ij):
     )
     RealPoint = jimport(
         'net.imglib2.RealPoint'
-    )
-    Point = jimport(
-        'mpicbg.models.Point'
-    )
-    PointMatch = jimport(
-        'mpicbg.models.PointMatch'
-    )
-    RigidModel2D = jimport(
-        'mpicbg.models.RigidModel2D'
-    )
-    AffineTransform = jimport(
-        'net.imglib2.realtransform.AffineTransform'
-    )
-    RealViews = jimport(
-        'net.imglib2.realtransform.RealViews'
     )
 
     # Add napari -> Java converters

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -39,6 +39,18 @@ def arr(coords):
     arr[:] = coords
     return arr
 
+
+def realPoint_from(coords: np.ndarray):
+    """
+    Creates a RealPoint from a numpy [1, D] array of coordinates.
+    :param coords: The [1, D] numpy array of coordinates
+    :return: a RealPoint
+    """
+    # JPype doesn't know whether to call the float or double.
+    # We make the choice for them using the function arr
+    return RealPoint(arr(coords))
+
+
 def _polyshape_to_layer_data(mask):
     vertices = mask.vertices()
     num_dims = mask.numDimensions()
@@ -139,12 +151,7 @@ def _rectangle_mask_to_layer(mask):
 
 
 def _polygon_data_to_mask(points):
-    # HACK: JPype doesn't know whether to call the float or double
-    def point_from_coords(coords):
-        arr = JArray(JDouble)(2)
-        arr[:] = coords
-        return RealPoint(arr)
-    pts = [point_from_coords(x) for x in points]
+    pts = [realPoint_from(x) for x in points]
     ptList = ArrayList(pts)
     return ClosedWritablePolygon2D(ptList)
 
@@ -163,13 +170,9 @@ def _polygon_mask_to_layer(mask):
 
 
 def _line_data_to_mask(points):
-    # HACK: JPype doesn't know whether to call the float or double
-    def point_from_coords(coords):
-        arr = JArray(JDouble)(2)
-        arr[:] = coords
-        return RealPoint(arr)
-    pts = [point_from_coords(x) for x in points]
-    return DefaultWritableLine(pts[0], pts[1])
+    start = realPoint_from(points[0])
+    end = realPoint_from(points[1])
+    return DefaultWritableLine(start, end)
 
 
 def _line_mask_to_data(mask):
@@ -196,11 +199,7 @@ def _line_mask_to_layer(mask):
 
 
 def _path_data_to_mask(points):
-    def point_from_coords(coords):
-        arr = JArray(JDouble)(2)
-        arr[:] = coords
-        return RealPoint(arr)
-    pts = [point_from_coords(x) for x in points]
+    pts = [realPoint_from(x) for x in points]
     ptList = ArrayList(pts)
     return DefaultWritablePolyline(ptList)
 

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -53,7 +53,7 @@ def _polyshape_to_layer_data(mask):
 # -- Ellipses -- #
 
 
-def _ellipse_layer_to_mask(pts):
+def _ellipse_data_to_mask(pts):
     center = np.mean(pts, axis=0)
     radii = np.abs(pts[0, :] - center)
     return ClosedWritableEllipsoid(center, radii)
@@ -80,7 +80,7 @@ def _ellipse_mask_to_layer(mask):
 # -- Boxes -- #
 
 
-def _rectangle_layer_to_mask(points):
+def _rectangle_data_to_mask(points):
     # find rectangle min
     origin = np.array([0, 0])
     dists = [np.linalg.norm(origin - pt) for pt in points]
@@ -97,7 +97,7 @@ def _rectangle_layer_to_mask(points):
         return ClosedWritableBox(arr(min), arr(max))
     # Return polygon if not
     else:
-        return _polygon_layer_to_mask(points)
+        return _polygon_data_to_mask(points)
 
 
 def _rectangle_mask_to_data(mask):
@@ -118,7 +118,7 @@ def _rectangle_mask_to_layer(mask):
 # -- Polygons -- ##
 
 
-def _polygon_layer_to_mask(points):
+def _polygon_data_to_mask(points):
     # HACK: JPype doesn't know whether to call the float or double
     def point_from_coords(coords):
         arr = JArray(JDouble)(2)
@@ -142,7 +142,7 @@ def _polygon_mask_to_layer(mask):
 # -- Lines -- ##
 
 
-def _line_layer_to_mask(points):
+def _line_data_to_mask(points):
     # HACK: JPype doesn't know whether to call the float or double
     def point_from_coords(coords):
         arr = JArray(JDouble)(2)
@@ -175,7 +175,7 @@ def _line_mask_to_layer(mask):
 # -- Paths -- ##
 
 
-def _path_layer_to_mask(points):
+def _path_data_to_mask(points):
     def point_from_coords(coords):
         arr = JArray(JDouble)(2)
         arr[:] = coords
@@ -222,15 +222,15 @@ def _layer_to_roitree(layer: Shapes):
     masks = ArrayList()
     for pts, shape_type in zip(layer.data, layer.shape_type):
         if shape_type == 'ellipse':
-            shape = _ellipse_layer_to_mask(pts)
+            shape = _ellipse_data_to_mask(pts)
         elif shape_type == 'rectangle':
-            shape = _rectangle_layer_to_mask(pts)
+            shape = _rectangle_data_to_mask(pts)
         elif shape_type == 'polygon':
-            shape = _polygon_layer_to_mask(pts)
+            shape = _polygon_data_to_mask(pts)
         elif shape_type == 'line':
-            shape = _line_layer_to_mask(pts)
+            shape = _line_data_to_mask(pts)
         elif shape_type == 'path':
-            shape = _path_layer_to_mask(pts)
+            shape = _path_data_to_mask(pts)
         else:
             raise NotImplementedError(f"Shape type {shape_type} cannot yet be converted!")
         masks.add(shape)

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -54,8 +54,6 @@ def _polyshape_to_layer_data(mask):
 
 
 def _ellipse_layer_to_mask(pts):
-    if pts.shape[0] == 2:
-        return pts[0, :], pts[1, :]
     center = np.mean(pts, axis=0)
     radii = np.abs(pts[0, :] - center)
     return ClosedWritableEllipsoid(center, radii)

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -63,9 +63,7 @@ def _ellipse_layer_to_mask(pts):
 
 def _ellipse_mask_to_data(mask):
     center = mask.center().positionAsDoubleArray()
-    # center = ij.py.from_java(center)
     radii = mask.minAsDoubleArray()
-    # radii = ij.py.from_java(radii)
     for i in range(radii.length):
         radii[i] = mask.semiAxisLength(i)
     data = np.zeros((2, center.length))

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -11,45 +11,23 @@ from labeling.Labeling import Labeling
 # -- Labels / ImgLabelings -- #
 
 
-def _delete_labeling_files(filepath):
+def _imglabeling_to_layer(ij, imgLabeling) -> Labels:
     """
-    Removes any Labeling data left over at filepath
-    :param filepath: the filepath where Labeling (might have) saved data
+    Converts a Java ImgLabeling to a napari Labels layer
+    :param imgLabeling: the Java ImgLabeling
+    :return: a Labels layer
     """
-    pth_bson = filepath + '.bson'
-    pth_tif = filepath + '.tif'
-    if os.path.exists(pth_tif):
-        os.remove(pth_tif)
-    if os.path.exists(pth_bson):
-        os.remove(pth_bson)
-
-
-def _imglabeling_to_layer(ij, labeling):
-    """Converts a Labeling to a Labels layer"""
-    labels = ij.context().getService(LabelingIOService)
-    # Convert the data to an ImgLabeling
-    data = ij.convert().convert(labeling, ImgLabeling)
-
-    # Save the image on the java side
-    tmp_pth = os.getcwd() + '/tmp'
-    tmp_pth_bson = tmp_pth + '.bson'
-    tmp_pth_tif = tmp_pth + '.tif'
-    try:
-        _delete_labeling_files(tmp_pth)
-        labels.save(data, tmp_pth_tif) # TODO: improve, likely utilizing the data's name
-    except Exception:
-        print('Failed to save the data')
-    
-    # Load the labeling on the python side
-    labeling = Labeling.from_file(tmp_pth_bson)
-    _delete_labeling_files(tmp_pth)
+    labeling: Labeling = ij.py._imglabeling_to_labeling(imgLabeling)
     return _ntypes._labeling_to_layer(labeling)
 
 
 def _layer_to_imglabeling(ij, layer: Labels):
-    """Converts a Labels layer to a Labeling"""
-    labeling = _ntypes._layer_to_labeling(layer)
-    
+    """
+    Converts a napari Labels layer to a Java ImgLabeling
+    :param layer: a Labels layer
+    :return: the Java ImgLabeling
+    """
+    labeling: Labeling = _ntypes._layer_to_labeling(layer)
     return ij.py.to_java(labeling)
 
 

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -157,6 +157,10 @@ def _polygon_data_to_mask(points):
 
 
 def _polygon_mask_to_data(mask):
+    """
+    Polygons are described in the Shapes layer as a set of points.
+    This is all a Polyshape is, so a mask's data is just the Polyshape's data.
+    """
     return _polyshape_to_layer_data(mask)
 
 
@@ -205,6 +209,10 @@ def _path_data_to_mask(points):
 
 
 def _path_mask_to_data(mask):
+    """
+    Paths are described in the Shapes layer as a set of points.
+    This is all a Polyshape is, so a mask's data is just the Polyshape's data.
+    """
     return _polyshape_to_layer_data(mask)
 
 

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -1,0 +1,147 @@
+import os
+from typing import List
+import numpy as np
+from napari.layers import Labels, Shapes
+from napari_imagej import _ntypes
+from scyjava import Converter, Priority, jimport, add_py_converter, add_java_converter
+from labeling.Labeling import Labeling
+
+
+def _delete_labeling_files(filepath):
+    """
+    Removes any Labeling data left over at filepath
+    :param filepath: the filepath where Labeling (might have) saved data
+    """
+    pth_bson = filepath + '.bson'
+    pth_tif = filepath + '.tif'
+    if os.path.exists(pth_tif):
+        os.remove(pth_tif)
+    if os.path.exists(pth_bson):
+        os.remove(pth_bson)
+
+
+def _imglabeling_to_layer(ij, labeling):
+    """Converts a Labeling to a Labels layer"""
+    labels = ij.context().getService(LabelingIOService)
+    # Convert the data to an ImgLabeling
+    data = ij.convert().convert(labeling, ImgLabeling)
+
+    # Save the image on the java side
+    tmp_pth = os.getcwd() + '/tmp'
+    tmp_pth_bson = tmp_pth + '.bson'
+    tmp_pth_tif = tmp_pth + '.tif'
+    try:
+        _delete_labeling_files(tmp_pth)
+        labels.save(data, tmp_pth_tif) # TODO: improve, likely utilizing the data's name
+    except Exception:
+        print('Failed to save the data')
+    
+    # Load the labeling on the python side
+    labeling = Labeling.from_file(tmp_pth_bson)
+    _delete_labeling_files(tmp_pth)
+    return _ntypes._labeling_to_layer(labeling)
+
+
+def _layer_to_imglabeling(ij, layer: Labels):
+    """Converts a Labels layer to a Labeling"""
+    labeling = _ntypes._layer_to_labeling(layer)
+    
+    return ij.py.to_java(labeling)
+
+
+def _format_ellipse_points(pts):
+    if pts.shape[0] == 2:
+        return pts[0, :], pts[1, :]
+    center = np.mean(pts, axis=0)
+    radii = np.abs(pts[0, :] - center)
+
+    return center, radii
+
+
+def _shapes_to_realmasks(layer: Shapes):
+    """Converts a Shapes layer to a RealMask or a list of them."""
+    masks = []
+    for pts, shape_type in zip(layer.data, layer.shape_type):
+        if shape_type == 'ellipse':
+            center, radii = _format_ellipse_points(pts)
+            masks.append(ClosedWritableEllipsoid(center, radii))
+    return masks[0] if len(masks) == 1 else masks
+
+
+def _ellipsoid_to_shapes(ij, mask):
+    center = mask.center().positionAsDoubleArray()
+    center = ij.py.from_java(center)
+    radii = mask.minAsDoubleArray()
+    radii = ij.py.from_java(radii)
+    for i in range(len(radii)):
+        radii[i] = mask.semiAxisLength(i)
+    data = np.zeros((2, len(center)))
+    data[0, :] = center
+    data[1, :] = radii
+    layer = Shapes()
+    layer.add_ellipses(data)
+    return layer
+    
+
+def _napari_to_java_converters(ij) -> List[Converter]:
+    return [
+        Converter(
+            predicate=lambda obj: isinstance(obj, Labels),
+            converter=lambda obj: _layer_to_imglabeling(ij, obj),
+            priority=Priority.VERY_HIGH
+        ),
+        Converter(
+            predicate=lambda obj: isinstance(obj, Shapes),
+            converter=_shapes_to_realmasks,
+            priority=Priority.VERY_HIGH
+        ),
+    ]
+
+
+def _java_to_napari_converters(ij) -> List[Converter]:
+    return [
+        Converter(
+            predicate=lambda obj: isinstance(obj, ImgLabeling),
+            converter=_imglabeling_to_layer,
+            priority=Priority.VERY_HIGH
+        ),
+        Converter(
+            predicate=lambda obj: isinstance(obj, SuperEllipsoid),
+            converter=lambda obj: _ellipsoid_to_shapes(ij, obj),
+            priority=Priority.VERY_HIGH
+        ),
+    ]
+
+
+def init_napari_converters(ij):
+    """
+    Initializes all classes needed by the converters,
+    then adding them to the ScyJava converter framework.
+    :param ij: An ImageJ gateway
+    """
+    # Initialize needed classes
+    global LabelingIOService
+    global SuperEllipsoid
+    global ImgLabeling
+    global ClosedWritableEllipsoid
+
+    LabelingIOService = jimport(
+        'io.scif.labeling.LabelingIOService'
+    )
+    SuperEllipsoid = jimport(
+        'net.imglib2.roi.geom.real.SuperEllipsoid'
+    )
+    ClosedWritableEllipsoid = jimport(
+        'net.imglib2.roi.geom.real.ClosedWritableEllipsoid'
+    )
+    ImgLabeling = jimport(
+        'net.imglib2.roi.labeling.ImgLabeling'
+    )
+
+    # Add napari -> Java converters
+    for converter in _napari_to_java_converters(ij):
+        add_java_converter(converter)
+
+    # Add Java -> napari converters
+    for converter in _java_to_napari_converters(ij):
+        add_py_converter(converter)

--- a/src/napari_imagej/_ntypes.py
+++ b/src/napari_imagej/_ntypes.py
@@ -18,5 +18,5 @@ def _layer_to_labeling(layer: Labels):
         labeling.metadata = metadata["metadata"]
         return labeling
     else :
-        return Labeling.fromValues(layer.data, layer.data.shape)
+        return Labeling.fromValues(layer.data)
     

--- a/src/napari_imagej/_ntypes.py
+++ b/src/napari_imagej/_ntypes.py
@@ -10,7 +10,7 @@ def _labeling_to_layer(labeling: Labeling):
 
 def _layer_to_labeling(layer: Labels):
     """Converts a Labels layer to a Labeling"""
-    if layer.metadata["pyLabelingData"] is not None:
+    if "pyLabelingData" in layer.metadata:
         metadata = vars(layer.metadata["pyLabelingData"])
         labeling = Labeling(shape=layer.data.shape)
         labeling.result_image = layer.data

--- a/src/napari_imagej/_ptypes.py
+++ b/src/napari_imagej/_ptypes.py
@@ -54,11 +54,11 @@ class PTypes:
 
         # Shapes
         self._shapes = {
-            jimport('net.imglib2.roi.geom.real.Line'):                'napari.types.ShapesData',
-            jimport('net.imglib2.roi.geom.real.Box'):                 'napari.types.ShapesData',
-            jimport('net.imglib2.roi.geom.real.SuperEllipsoid'):      'napari.types.ShapesData',
-            jimport('net.imglib2.roi.geom.real.Polygon2D'):           'napari.types.ShapesData',
-            jimport('net.imglib2.roi.geom.real.Polyline'):            'napari.types.ShapesData',
+            jimport('net.imglib2.roi.geom.real.Line'):                'napari.layers.Shapes',
+            jimport('net.imglib2.roi.geom.real.Box'):                 'napari.layers.Shapes',
+            jimport('net.imglib2.roi.geom.real.SuperEllipsoid'):      'napari.layers.Shapes',
+            jimport('net.imglib2.roi.geom.real.Polygon2D'):           'napari.layers.Shapes',
+            jimport('net.imglib2.roi.geom.real.Polyline'):            'napari.layers.Shapes',
         }
 
         # Surfaces

--- a/src/napari_imagej/_ptypes.py
+++ b/src/napari_imagej/_ptypes.py
@@ -59,6 +59,7 @@ class PTypes:
             jimport('net.imglib2.roi.geom.real.SuperEllipsoid'):      'napari.layers.Shapes',
             jimport('net.imglib2.roi.geom.real.Polygon2D'):           'napari.layers.Shapes',
             jimport('net.imglib2.roi.geom.real.Polyline'):            'napari.layers.Shapes',
+            jimport('net.imagej.roi.ROITree'):                        'napari.layers.Shapes',
         }
 
         # Surfaces

--- a/src/napari_imagej/_tests/conftest.py
+++ b/src/napari_imagej/_tests/conftest.py
@@ -1,3 +1,23 @@
+from typing import Generator
 import pytest
+import imagej
 
-import napari.utils._testsupport
+from napari_imagej._function import ImageJWidget
+from napari import Viewer
+# This import is mistakenly considered unused; we need it for imagej_widget!
+from napari.utils._testsupport import make_napari_viewer
+
+@pytest.fixture(scope="module")
+def ij():
+    return imagej.init()
+
+@pytest.fixture
+def imagej_widget(make_napari_viewer) -> Generator[ImageJWidget, None, None]:
+    # Create widget
+    viewer: Viewer = make_napari_viewer()
+    ij_widget: ImageJWidget = ImageJWidget(viewer)
+
+    yield ij_widget
+
+    # Cleanup -> Close the widget, trigger ImageJ shutdown
+    ij_widget.close()

--- a/src/napari_imagej/_tests/test_function.py
+++ b/src/napari_imagej/_tests/test_function.py
@@ -1,7 +1,3 @@
-from typing import Generator
-from napari import Viewer
-
-import pytest
 from napari_imagej._function import ImageJWidget
 from qtpy.QtWidgets import (
     QWidget,
@@ -12,16 +8,6 @@ from qtpy.QtWidgets import (
     QLineEdit,
 )
 
-@pytest.fixture
-def imagej_widget(make_napari_viewer) -> Generator[ImageJWidget, None, None]:
-    # Create widget
-    viewer: Viewer = make_napari_viewer()
-    ij_widget: ImageJWidget = ImageJWidget(viewer)
-
-    yield ij_widget
-
-    # Cleanup -> Close the widget, trigger ImageJ shutdown
-    ij_widget.close()
 
 def test_widget_layout(imagej_widget: ImageJWidget):
     """Ensures a vertical widget layout."""

--- a/src/napari_imagej/_tests/test_ntypes.py
+++ b/src/napari_imagej/_tests/test_ntypes.py
@@ -1,9 +1,15 @@
 from typing import Any, Dict, List
 import pytest
 import numpy as np
+from scyjava import jimport
+import imagej
 from napari_imagej._ntypes import _labeling_to_layer, _layer_to_labeling
 from labeling.Labeling import Labeling
-from napari.layers import Labels
+from napari.layers import Labels, Shapes
+
+@pytest.fixture()
+def ij_fixture():
+    return imagej.init()
 
 def assert_labels_equality(
     exp: Dict[str, Any], act: Dict[str, Any], ignored_keys: List[str]
@@ -67,3 +73,49 @@ def test_labels_to_labeling(py_labeling):
     exp_img = labels.data
     act_img, _ = labeling.get_result()
     assert np.array_equal(exp_img, act_img)
+
+@pytest.fixture
+def ellipse_mask(ij_fixture):
+    ClosedWritableEllipsoid = jimport('net.imglib2.roi.geom.real.ClosedWritableEllipsoid')
+    return ClosedWritableEllipsoid([20, 20], [10, 10])
+
+@pytest.fixture
+def ellipse_layer():
+    shp = Shapes()
+    data = np.zeros((2, 2))
+    data[0, :] = [30, 30] # ceter
+    data[1, :] = [10, 10] # axes
+    shp.add_ellipses(data)
+    return shp
+
+def test_ellipse_to_shapes(ij_fixture, ellipse_mask):
+    py_mask = ij_fixture.py.from_java(ellipse_mask)
+    assert isinstance(py_mask, Shapes)
+    types = py_mask.shape_type
+    assert len(types) == 1
+    assert types[0] == 'ellipse'
+    data = py_mask.data
+    assert len(data) == 1
+    ellipse_data = data[0]
+    assert len(ellipse_data) == 4
+    assert np.array_equal(ellipse_data[0], np.array([10, 10]))
+    assert np.array_equal(ellipse_data[1], np.array([30, 10]))
+    assert np.array_equal(ellipse_data[2], np.array([30, 30]))
+    assert np.array_equal(ellipse_data[3], np.array([10, 30]))
+
+def test_shapes_to_ellipse(ij_fixture, ellipse_layer):
+    # Assert shapes conversion to ellipse
+    j_mask = ij_fixture.py.to_java(ellipse_layer)
+    ClosedWritableEllipsoid = jimport('net.imglib2.roi.geom.real.ClosedWritableEllipsoid')
+    assert isinstance(j_mask, ClosedWritableEllipsoid)
+    # Assert dimensionality
+    assert j_mask.numDimensions() == 2
+    # Assert center position
+    center = j_mask.center().positionAsDoubleArray()
+    center = ij_fixture.py.from_java(center)
+    assert center == [30, 30]
+    # Assert semi-axis lengths   
+    assert j_mask.semiAxisLength(0) == 10
+    assert j_mask.semiAxisLength(1) == 10
+
+    

--- a/src/napari_imagej/_tests/test_ntypes.py
+++ b/src/napari_imagej/_tests/test_ntypes.py
@@ -21,7 +21,7 @@ def assert_labels_equality(
         assert exp[key] == act[key]
 
 @pytest.fixture(scope="module")
-def py_labeling():
+def py_labeling() -> Labeling:
 
     a = np.zeros((4,4), np.int32)
     a[:2] = 1
@@ -40,6 +40,11 @@ def py_labeling():
     merger = Labeling.fromValues(np.zeros((4, 4), np.int32))
     merger.iterate_over_images(example1_images, source_ids=['a', 'b', 'c', 'd'])
     return merger
+
+@pytest.fixture(scope="module")
+def labels_layer(py_labeling: Labeling) -> Labels:
+    img, _ = py_labeling.get_result()
+    return Labels(img)
 
 def test_labeling_circular_equality(py_labeling):
     expected: Labeling = py_labeling
@@ -74,6 +79,15 @@ def test_labels_to_labeling(py_labeling):
     exp_img = labels.data
     act_img, _ = labeling.get_result()
     assert np.array_equal(exp_img, act_img)
+
+def test_labels_to_imgLabeling(ij_fixture, labels_layer):
+    ImgLabeling = jimport('net.imglib2.roi.labeling.ImgLabeling')
+    converted: ImgLabeling = ij_fixture.py.to_java(labels_layer)
+    exp_img: np.ndarray= labels_layer.data
+    act_img: np.ndarray = ij_fixture.py.from_java(converted.getIndexImg())
+    breakpoint()
+    assert np.array_equal(exp_img, act_img)
+
 
 # -- SHAPES / ROIS -- #
 

--- a/src/napari_imagej/_tests/test_ntypes.py
+++ b/src/napari_imagej/_tests/test_ntypes.py
@@ -8,7 +8,7 @@ from napari_imagej._ntypes import _labeling_to_layer, _layer_to_labeling
 from labeling.Labeling import Labeling
 from napari.layers import Labels, Shapes
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def ij_fixture():
     return imagej.init()
 
@@ -42,9 +42,30 @@ def py_labeling() -> Labeling:
     return merger
 
 @pytest.fixture(scope="module")
-def labels_layer(py_labeling: Labeling) -> Labels:
+def labels_with_metadata(py_labeling: Labeling) -> Labels:
+    img, data = py_labeling.get_result()
+    return Labels(img, metadata={"pyLabelingData": data})
+
+@pytest.fixture(scope="module")
+def labels_without_metadata(py_labeling: Labeling) -> Labels:
     img, _ = py_labeling.get_result()
     return Labels(img)
+
+@pytest.fixture(scope="module")
+def imgLabeling(ij_fixture):
+    img = np.zeros((4, 4), dtype=np.int32)
+    img[:2, :2] = 6
+    img[:2, 2:] = 3
+    img[2:, :2] = 7
+    img[2:, 2:] = 4
+    img_java = ij_fixture.py.to_java(img)
+    sets = [[], [1], [2], [1, 2], [2, 3], [3], [1, 4], [3, 4]]
+    sets = [set(l) for l in sets]
+    sets_java = ij_fixture.py.to_java(sets)
+
+    ImgLabeling = jimport("net.imglib2.roi.labeling.ImgLabeling")
+    return ImgLabeling.fromImageAndLabelSets(img_java, sets_java)
+
 
 def test_labeling_circular_equality(py_labeling):
     expected: Labeling = py_labeling
@@ -80,13 +101,75 @@ def test_labels_to_labeling(py_labeling):
     act_img, _ = labeling.get_result()
     assert np.array_equal(exp_img, act_img)
 
-def test_labels_to_imgLabeling(ij_fixture, labels_layer):
+def test_labels_with_metadata_to_imgLabeling(ij_fixture, labels_with_metadata):
     ImgLabeling = jimport('net.imglib2.roi.labeling.ImgLabeling')
-    converted: ImgLabeling = ij_fixture.py.to_java(labels_layer)
-    exp_img: np.ndarray= labels_layer.data
+    converted: ImgLabeling = ij_fixture.py.to_java(labels_with_metadata)
+    exp_img: np.ndarray= labels_with_metadata.data
     act_img: np.ndarray = ij_fixture.py.from_java(converted.getIndexImg())
-    breakpoint()
     assert np.array_equal(exp_img, act_img)
+
+
+def test_labels_with_metadata_circular(ij_fixture, labels_with_metadata):
+    ImgLabeling = jimport('net.imglib2.roi.labeling.ImgLabeling')
+    converted: ImgLabeling = ij_fixture.py.to_java(labels_with_metadata)
+    converted_back: Labels = ij_fixture.py.from_java(converted)
+    exp_img: np.ndarray = labels_with_metadata.data
+    act_img: np.ndarray = converted_back.data
+    assert np.array_equal(exp_img, act_img)
+
+
+def _assert_image_mapping(exp_img: np.ndarray, act_img: np.ndarray) -> Dict[int, int]:
+    """
+    Asserts a CONSISTENT mapping between values in exp_img and act_img.
+
+    i.e. if
+    exp_img[x, y] = a and act_img[x, y] = b for any x,y
+    then
+    np.where(exp_img == a) == np.where(act_img == b)
+
+    :param exp_img: the first image
+    :param act_img: the second image
+    :return: the mappings of a -> b
+    """
+    mapping: Dict[int, int] = {}
+    for e_x, a_x in zip(exp_img, act_img):
+        for e, a in zip(e_x, a_x):
+            if e in mapping:
+                assert mapping[e] == a
+            else:
+                mapping[e] = a
+    return mapping
+
+
+def test_labels_without_metadata_to_imgLabeling(ij_fixture, labels_without_metadata):
+    ImgLabeling = jimport('net.imglib2.roi.labeling.ImgLabeling')
+    converted: ImgLabeling = ij_fixture.py.to_java(labels_without_metadata)
+    exp_img: np.ndarray= labels_without_metadata.data
+    act_img: np.ndarray = ij_fixture.py.from_java(converted.getIndexImg())
+    # We cannot assert image equality due to https://github.com/Labelings/Labeling/issues/16
+    # So we do the next best thing
+    _assert_image_mapping(exp_img, act_img)
+
+
+def test_labels_without_metadata_circular(ij_fixture, labels_without_metadata):
+    ImgLabeling = jimport('net.imglib2.roi.labeling.ImgLabeling')
+    converted: ImgLabeling = ij_fixture.py.to_java(labels_without_metadata)
+    converted_back: Labels = ij_fixture.py.from_java(converted)
+    exp_img: np.ndarray = labels_without_metadata.data
+    act_img: np.ndarray = converted_back.data
+    # We cannot assert image equality due to https://github.com/Labelings/Labeling/issues/16
+    # So we do the next best thing
+    _assert_image_mapping(exp_img, act_img)
+
+
+def test_imgLabeling_to_labels(ij_fixture, imgLabeling):
+    converted: Labels = ij_fixture.py.from_java(imgLabeling)
+    exp_img: np.ndarray = ij_fixture.py.from_java(imgLabeling.getIndexImg())
+    act_img: np.ndarray= converted.data
+    # We cannot assert image equality due to https://github.com/Labelings/Labeling/issues/16
+    # So we do the next best thing
+    _assert_image_mapping(exp_img, act_img)
+
 
 
 # -- SHAPES / ROIS -- #

--- a/src/napari_imagej/_tests/test_ntypes.py
+++ b/src/napari_imagej/_tests/test_ntypes.py
@@ -170,14 +170,14 @@ def test_imgLabeling_to_labels(ij, imgLabeling):
 # -- SHAPES / ROIS -- #
 
 
-def assert_ROITree_conversion(ij, layer):
+def _assert_ROITree_conversion(ij, layer):
     roitree = ij.py.to_java(layer)
     ROITree = jimport('net.imagej.roi.ROITree')
     assert isinstance(roitree, ROITree)
     return roitree.children()
 
 
-def point_assertion(mask, pt: list, expected: bool) -> None:
+def _point_assertion(mask, pt: list, expected: bool) -> None:
     arr = JArray(JDouble)(len(pt))
     arr[:] = pt
     RealPoint = jimport('net.imglib2.RealPoint')
@@ -218,7 +218,7 @@ def test_ellipse_mask_to_layer(ij, ellipse_mask):
 
 def test_ellipse_layer_to_mask(ij, ellipse_layer):
     # Assert shapes conversion to ellipse
-    children = assert_ROITree_conversion(ij, ellipse_layer)
+    children = _assert_ROITree_conversion(ij, ellipse_layer)
     assert children.size() == 1
     j_mask = children.get(0).data()
     ClosedWritableEllipsoid = jimport('net.imglib2.roi.geom.real.ClosedWritableEllipsoid')
@@ -283,7 +283,7 @@ def test_rectangle_mask_to_layer(ij, rectangle_mask):
 
 def test_rectangle_layer_to_mask_box(ij, rectangle_layer_axis_aligned):
     # Assert shapes conversion to ellipse
-    children = assert_ROITree_conversion(ij, rectangle_layer_axis_aligned)
+    children = _assert_ROITree_conversion(ij, rectangle_layer_axis_aligned)
     assert children.size() == 1
     j_mask = children.get(0).data()
     ClosedWritableBox = jimport('net.imglib2.roi.geom.real.ClosedWritableBox')
@@ -301,7 +301,7 @@ def test_rectangle_layer_to_mask_box(ij, rectangle_layer_axis_aligned):
 
 def test_rectangle_layer_to_mask_polygon(ij, rectangle_layer_rotated):
     # Assert shapes conversion to ellipse
-    children = assert_ROITree_conversion(ij, rectangle_layer_rotated)
+    children = _assert_ROITree_conversion(ij, rectangle_layer_rotated)
     assert children.size() == 1
     j_mask = children.get(0).data()
     ClosedWritablePolygon2D = jimport('net.imglib2.roi.geom.real.ClosedWritablePolygon2D')
@@ -309,9 +309,9 @@ def test_rectangle_layer_to_mask_polygon(ij, rectangle_layer_rotated):
     # Assert dimensionality
     assert j_mask.numDimensions() == 2
     # Test some points
-    point_assertion(j_mask, [0, 0], True)
-    point_assertion(j_mask, [5, 5], True)
-    point_assertion(j_mask, [5, 6], False)
+    _point_assertion(j_mask, [0, 0], True)
+    _point_assertion(j_mask, [5, 5], True)
+    _point_assertion(j_mask, [5, 6], False)
 
 
 # -- POLYGONS -- #
@@ -356,7 +356,7 @@ def test_polygon_mask_to_layer(ij, polygon_mask):
 
 def test_polygon_layer_to_mask(ij, polygon_layer):
     # Assert shapes conversion to ellipse
-    children = assert_ROITree_conversion(ij, polygon_layer)
+    children = _assert_ROITree_conversion(ij, polygon_layer)
     assert children.size() == 1
     j_mask = children.get(0).data()
     ClosedWritablePolygon2D = jimport('net.imglib2.roi.geom.real.ClosedWritablePolygon2D')
@@ -364,10 +364,10 @@ def test_polygon_layer_to_mask(ij, polygon_layer):
     # Assert dimensionality
     assert j_mask.numDimensions() == 2
     # Test some points
-    point_assertion(j_mask, [0, 0], True)
-    point_assertion(j_mask, [3, 0], True)
-    point_assertion(j_mask, [2, 1], True)
-    point_assertion(j_mask, [5, 6], False)
+    _point_assertion(j_mask, [0, 0], True)
+    _point_assertion(j_mask, [3, 0], True)
+    _point_assertion(j_mask, [2, 1], True)
+    _point_assertion(j_mask, [5, 6], False)
 
 
 # -- LINES -- #
@@ -410,7 +410,7 @@ def test_line_mask_to_layer(ij, line_mask):
 
 def test_line_layer_to_mask(ij, line_layer):
     # Assert shapes conversion to ellipse
-    children = assert_ROITree_conversion(ij, line_layer)
+    children = _assert_ROITree_conversion(ij, line_layer)
     assert children.size() == 1
     j_mask = children.get(0).data()
     DefaultWritableLine = jimport('net.imglib2.roi.geom.real.DefaultWritableLine')
@@ -424,10 +424,10 @@ def test_line_layer_to_mask(ij, line_layer):
     j_mask.endpointTwo().localize(arr)
     assert ij.py.from_java(arr) == [4, -4]
     # Test some points
-    point_assertion(j_mask, [0, 0], True)
-    point_assertion(j_mask, [4, -4], True)
-    point_assertion(j_mask, [2, -2], True)
-    point_assertion(j_mask, [5, 6], False)
+    _point_assertion(j_mask, [0, 0], True)
+    _point_assertion(j_mask, [4, -4], True)
+    _point_assertion(j_mask, [2, -2], True)
+    _point_assertion(j_mask, [5, 6], False)
 
 
 # -- PATHS -- #
@@ -478,7 +478,7 @@ def test_path_mask_to_layer(ij, path_mask):
 
 def test_path_layer_to_mask(ij, path_layer):
     # Assert shapes conversion to ellipse
-    children = assert_ROITree_conversion(ij, path_layer)
+    children = _assert_ROITree_conversion(ij, path_layer)
     assert children.size() == 1
     j_mask = children.get(0).data()
     DefaultWritablePolyline = jimport('net.imglib2.roi.geom.real.DefaultWritablePolyline')
@@ -493,12 +493,12 @@ def test_path_layer_to_mask(ij, path_layer):
         a.localize(arr)
         assert ij.py.from_java(arr) == e
     # Test some points
-    point_assertion(j_mask, [0, 0], True)
-    point_assertion(j_mask, [2, -2], True)
-    point_assertion(j_mask, [4, -4], True)
-    point_assertion(j_mask, [6, -2], True)
-    point_assertion(j_mask, [8, 0], True)
-    point_assertion(j_mask, [5, 6], False)
+    _point_assertion(j_mask, [0, 0], True)
+    _point_assertion(j_mask, [2, -2], True)
+    _point_assertion(j_mask, [4, -4], True)
+    _point_assertion(j_mask, [6, -2], True)
+    _point_assertion(j_mask, [8, 0], True)
+    _point_assertion(j_mask, [5, 6], False)
 
 
 # -- ROITrees -- #


### PR DESCRIPTION
This PR adds support for conversion between napari [`Shapes`](https://napari.org/api/stable/napari.layers.Shapes.html) layers and `RealMask` ROIs. Specifically, we convert `Shapes` layers to [`ROITree`](https://github.com/imagej/imagej-common/blob/df5b9e7fd78c35b85ea4daca000d8061398935bd/src/main/java/net/imagej/roi/ROITree.java#L47)s.

Steps:
* [x] Convert `SuperEllipsoid`s
* [x] Convert `Box`es
* [x] Convert `Polygon`s
* [x] Convert `Line`s
* [x] Convert `Polyline`s
* [x] Convert `ROITree`s

Points of discussion:
* napari supports `rectangle`s that are *not* axis-aligned, while ImgLib2-roi does not. The current approach maps napari `rectangle`s to `Box`es *iff* they are axis-aligned, and to `Polygon`s otherwise. Circular conversion for non-axis-aligned rectangles is not supported, since we cannot yet specify that the resulting `Polygon` in Java came from a napari `rectangle`.
* Consider how to support the massaging of napari `Shapes` into modules that take a single ROI (i.e. *not* a `ROITree`). There are many ops that want a single ROI (e.g. [`DefaultElongation`](https://github.com/imagej/imagej-ops/blob/master/src/main/java/net/imagej/ops/geom/geom2d/DefaultElongation.java)) and we should support this. @ctrueden suggested [here](https://github.com/imagej/pyimagej/issues/128#issuecomment-1042337009) that we could do this through `org.scijava.convert.Converter`s...

TODO:
* [x] Merge imagej/napari-imagej#4

Closes imagej/pyimagej#128