### PR TITLE
Add primitive array support

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -15,6 +15,7 @@ channels:
 dependencies:
   # Project dependencies
   - napari
+  - magicgui >= 0.4.0
   - pyimagej >= 1.2.0
   - labeling >= 0.1.12
   # Test dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ channels:
 dependencies:
   # Project depenencies
   - napari
+  - magicgui >= 0.4.0
   - pyimagej >= 1.2.0
   - labeling >= 0.1.12
   # Project from source

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,9 @@ package_dir =
 
 # add your package requirements here
 install_requires =
-    napari
     labeling >= 0.1.12
+    napari
+    magicgui >= 0.4.0
     pyimagej >= 1.2.0
 
 [options.packages.find]

--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -38,7 +38,7 @@ def python_type_of(module_item):
         converted = converter(module_item)
         if converted is not None:
             return converted
-    raise ValueError(f"Unsupported Java ModuleItem: {module_item}. Let us know about the failure at https://forum.image.sc, or file an issue at https://github.com/imagej/napari-imagej!")
+    raise ValueError(f"Unsupported Java Type: {module_item.getType()}. Let us know about the failure at https://forum.image.sc, or file an issue at https://github.com/imagej/napari-imagej!")
 
 
 def _checkerUsingFunc(

--- a/src/napari_imagej/_ptypes.py
+++ b/src/napari_imagej/_ptypes.py
@@ -1,3 +1,4 @@
+from typing import List
 from napari_imagej.setup_imagej import java_import
 
 
@@ -5,18 +6,18 @@ class PTypes:
     def __init__(self):
         # Numbers
         self._numbers = {
-            java_import('[B'):                                            int,
-            java_import('[S'):                                            int,
-            java_import('[I'):                                            int,
-            java_import('[J'):                                            int,
-            java_import('[F'):                                            float,
-            java_import('[D'):                                            float,
             java_import('java.lang.Byte'):                                int,
+            java_import('[B'):                                            List[int],
             java_import('java.lang.Short'):                               int,
+            java_import('[S'):                                            List[int],
             java_import('java.lang.Integer'):                             int,
+            java_import('[I'):                                            List[int],
             java_import('java.lang.Long'):                                int,
+            java_import('[J'):                                            List[int],
             java_import('java.lang.Float'):                               float,
+            java_import('[F'):                                            List[float],
             java_import('java.lang.Double'):                              float,
+            java_import('[D'):                                            List[float],
             java_import('java.math.BigInteger'):                          int,
             java_import('net.imglib2.type.numeric.IntegerType'):          int,
             java_import('net.imglib2.type.numeric.RealType'):             float,
@@ -25,7 +26,7 @@ class PTypes:
 
         # Booleans
         self._booleans = {
-            java_import('[Z'):                                            bool,
+            java_import('[Z'):                                            List[bool],
             java_import('java.lang.Boolean'):                             bool,
             java_import('net.imglib2.type.BooleanType'):                  bool,
         }


### PR DESCRIPTION
With the great work on list inputs in magicgui 0.4.0, we can now support modules and Ops that take arrays as inputs.

This work is built on top of #12 and should not be merged until that work is merged.