### PR TITLE
Add support for SciJava Parameter styles

### DIFF
--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -1,10 +1,10 @@
 from functools import lru_cache
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 from scyjava import Priority, JavaIterable, JavaMap, JavaSet
 from inspect import Parameter, Signature, signature
 from magicgui import magicgui
 from napari import Viewer
-from napari_imagej._ptypes import TypeMappings, widget_for_style_and_type
+from napari_imagej._ptypes import TypeMappings, _supported_styles
 from napari_imagej.setup_imagej import ij, jc, log_debug
 
 
@@ -496,8 +496,27 @@ def _add_param_metadata(metadata: dict, key: str, value: Any) -> None:
         pass
 
 
+def _widget_for_style_and_type(
+    style: str, type_hint: Union[type, str]
+) -> Optional[str]:
+    """
+    Convenience function for interacting with _supported_styles
+    :param style: The SciJava style
+    :param type_hint: The PYTHON type for the parameter
+    :return: The best widget type, if it is known
+    """
+    if style not in _supported_styles:
+        return None
+    style_options = _supported_styles[style]
+    for k, v in style_options.items():
+        if issubclass(type_hint, k):
+            return v
+    return None
+
+
 def _add_scijava_metadata(
     unresolved_inputs: List["jc.ModuleItem"],
+    type_hints: Dict[str, Union[str, type]],
 ) -> Dict[str, Dict[str, Any]]:
     metadata = {}
     for input in unresolved_inputs:
@@ -515,9 +534,9 @@ def _add_scijava_metadata(
         if len(input.getChoices()) > 0:
             _add_param_metadata(param_map, "choices", input.getChoices())
         # Convert supported SciJava styles to widget types.
-        # TODO: can we avoid recomputing the type hint
-        type_hint = python_type_of(input)
-        widget_type = widget_for_style_and_type(input.getWidgetStyle(), type_hint)
+        widget_type = _widget_for_style_and_type(
+            input.getWidgetStyle(), type_hints[input.getName()]
+        )
         if widget_type is not None:
             _add_param_metadata(param_map, "widget_type", widget_type)
 
@@ -576,6 +595,8 @@ def functionify_module_execution(
 
     # Add metadata for widget creation
     _add_napari_metadata(module_execute, info, unresolved_inputs)
-    magic_kwargs = _add_scijava_metadata(unresolved_inputs)
+    magic_kwargs = _add_scijava_metadata(
+        unresolved_inputs, module_execute.__annotation__
+    )
 
     return (module_execute, magic_kwargs)

--- a/src/napari_imagej/_ptypes.py
+++ b/src/napari_imagej/_ptypes.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict, List, Optional
+from typing import Dict, List
 from napari_imagej.setup_imagej import jc
 
 
@@ -148,25 +148,13 @@ class TypeMappings:
 # The definitive mapping of scyjava widget styles to magicgui widget types
 # This map allows us to determine the "best" widget for a given ModuleItem.
 # For particular styles, there are sometimes multiple corresponding widgets.
-# We then have to differentiate by type
+# We then have to differentiate by the PYTHON type of the parameter.
 _supported_styles: Dict[str, Dict[type, str]] = {
+    # ChoiceWidget styles
+    "listBox": {str: "Select"},
+    "radioButtonHorizontal": {str: "RadioButtons"},
+    "radioButtonVertical": {str: "RadioButtons"},
     # NumberWidget styles
     "slider": {int: "Slider", float: "FloatSlider"},
     "spinner": {int: "SpinBox", float: "FloatSpinBox"},
 }
-
-
-def widget_for_style_and_type(style: str, type_hint: type) -> Optional[str]:
-    """
-    Convenience function for interacting with _supported_styles
-    :param style: The SciJava style
-    :param type: The PYTHON type for the parameter
-    :return: The best widget type, if it is known
-    """
-    if style not in _supported_styles:
-        return None
-    style_options = _supported_styles[style]
-    for k, v in style_options.items():
-        if issubclass(type_hint, k):
-            return v
-    return None

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -138,6 +138,12 @@ class DummyModuleItem:
     def setChoices(self, val):
         self._choices = val
 
+    def getWidgetStyle(self):
+        return self._style
+
+    def setWidgetStyle(self, val):
+        self._style = val
+
 
 direct_match_pairs = [(jtype, ptype) for jtype, ptype in TypeMappings().ptypes.items()]
 assignable_match_pairs = [
@@ -414,7 +420,7 @@ def test_add_param_metadata():
 
 @pytest.fixture
 def metadata_module_item(ij) -> DummyModuleItem:
-    item: DummyModuleItem = DummyModuleItem(name="foo")
+    item: DummyModuleItem = DummyModuleItem(name="foo", jtype=jc.Double)
     maxVal = ij.py.to_java(20.0)
     item.setMaximumValue(maxVal)
     minVal = ij.py.to_java(10.0)
@@ -428,6 +434,8 @@ def metadata_module_item(ij) -> DummyModuleItem:
     item.setDescription(description)
     choices = ij.py.to_java(["a", "b", "c"])
     item.setChoices(choices)
+    style = ij.py.to_java("spinner")
+    item.setWidgetStyle(style)
 
     return item
 
@@ -449,6 +457,7 @@ def test_add_scijava_metadata(metadata_module_item: DummyModuleItem):
     assert param_map["label"] == "bar"
     assert param_map["tooltip"] == "The foo."
     assert param_map["choices"] == ["a", "b", "c"]
+    assert param_map["widget_type"] == "FloatSpinBox"
 
 
 def test_add_scijava_metadata_empty_choices(ij, metadata_module_item: DummyModuleItem):

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -4,7 +4,7 @@ import pytest
 from inspect import Parameter, _empty
 from napari_imagej import _module_utils
 from napari_imagej.setup_imagej import JavaClasses
-from napari_imagej._ptypes import TypeMappings
+from napari_imagej._ptypes import TypeMappings, _supported_styles
 
 
 class JavaClassesTest(JavaClasses):
@@ -442,7 +442,7 @@ def metadata_module_item(ij) -> DummyModuleItem:
 
 def test_add_scijava_metadata(metadata_module_item: DummyModuleItem):
     metadata: Dict[str, Dict[str, Any]] = _module_utils._add_scijava_metadata(
-        [metadata_module_item]
+        [metadata_module_item], {"foo": float}
     )
 
     # Assert only 'foo' key in metadata
@@ -466,7 +466,7 @@ def test_add_scijava_metadata_empty_choices(ij, metadata_module_item: DummyModul
     metadata_module_item.setChoices(empty_list)
 
     metadata: Dict[str, Dict[str, Any]] = _module_utils._add_scijava_metadata(
-        [metadata_module_item]
+        [metadata_module_item], {"foo": float}
     )
 
     # Assert only 'foo' key in metadata
@@ -481,6 +481,14 @@ def test_add_scijava_metadata_empty_choices(ij, metadata_module_item: DummyModul
     assert param_map["label"] == "bar"
     assert param_map["tooltip"] == "The foo."
     assert "choices" not in param_map
+
+
+def test_widget_for_style_and_type():
+
+    for style, map in _supported_styles.items():
+        for type_hint, expected in map.items():
+            actual = _module_utils._widget_for_style_and_type(style, type_hint)
+            assert expected == actual
 
 
 def test_modify_functional_signature():


### PR DESCRIPTION
We can map SciJava styles to different widget types. For example, the [`NumberWidget`](https://github.com/scijava/scijava-common/blob/309dc33241cefab2a2207ae31b32c8f137072996/src/main/java/org/scijava/widget/NumberWidget.java#L37) styles allow SciJava Parameters to specify whether they'd like to be graphically represented as a slider or a spinner.

We add this functionality through a `Dict[str, Dict[type, str]]`, which maps SciJava style and python type to the adequate magicgui widget. The internal `Dict[type, str]` allows us to differentiate between, for example, magicgui's `SpinBox` and `FloatSpinBox`.

As it is the final box for the issue, this PR will close #1

TODO:
* [x] Add support for more styles
* [x] Thoroughly test
* [x] Clean, both in terms of linting and in terms of code