### PR TITLE
Account for ModuleItem.getChoices() being null

### DIFF
--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -531,8 +531,9 @@ def _add_scijava_metadata(
         # With no choices, the returned list will be empty.
         # Unfortunately, magicgui doesn't know how to handle an empty list,
         # so we only add it if it is not empty.
-        if len(input.getChoices()) > 0:
-            _add_param_metadata(param_map, "choices", input.getChoices())
+        choices = input.getChoices()
+        if choices is not None and len(choices) > 0:
+            _add_param_metadata(param_map, "choices", choices)
         # Convert supported SciJava styles to widget types.
         widget_type = _widget_for_style_and_type(
             input.getWidgetStyle(), type_hints[input.getName()]

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -468,9 +468,18 @@ def test_add_scijava_metadata(metadata_module_item: DummyModuleItem):
     assert param_map["widget_type"] == "FloatSpinBox"
 
 
-def test_add_scijava_metadata_empty_choices(ij, metadata_module_item: DummyModuleItem):
-    # Make choices an empty list
-    empty_list = ij.py.to_java([])
+choiceList = [
+    [],
+    None,
+]
+
+
+@pytest.mark.parametrize("choices", choiceList)
+def test_add_scijava_metadata_empty_choices(
+    ij, choices, metadata_module_item: DummyModuleItem
+):
+    # set the choices
+    empty_list = ij.py.to_java(choices)
     metadata_module_item.setChoices(empty_list)
 
     metadata: Dict[str, Dict[str, Any]] = _module_utils._add_scijava_metadata(


### PR DESCRIPTION
Sometimes, [`ModuleItem.getChoices()`](https://github.com/scijava/scijava-common/blob/309dc33241cefab2a2207ae31b32c8f137072996/src/main/java/org/scijava/module/ModuleItem.java#L200) returns `null`, and sometimes it returns an empty list. We did not account for the former situation.

UNTIL NOW!