### PR TITLE
Fix MacOS support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,19 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        platform: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.7', '3.10']
 
         # Breaks due to https://github.com/jpype-project/jpype/issues/1009
         # Should be included once the fix is released
         exclude:
           - platform: windows-latest
             python-version: "3.10"
+        include:
+          - platform: windows-latest
+            python-version: "3.9"
+    env:
+      AWT_FORCE_HEADFUL: true
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,6 @@ jobs:
         include:
           - platform: windows-latest
             python-version: "3.9"
-    env:
-      # We run headless on CI. This yields issues on Mac, where running Java
-      # headless will alter the screen size on Python, leading to errors. Adding
-      # this environment variable prevents Java from modifying the screen size.
-      AWT_FORCE_HEADFUL: true
 
     steps:
       - uses: actions/checkout@v2
@@ -65,6 +60,14 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
+      
+      # We run headless on CI. This yields issues on Mac, where running Java
+      # headless will alter the screen size on Python, leading to errors. Adding
+      # this environment variable prevents Java from modifying the screen size.
+      - name: Set MacOS environment variables
+        if: runner.os == 'MacOS'
+        run: |
+          echo "AWT_FORCE_HEADFUL=true" >> $GITHUB_ENV
 
       - name: Install napari-imagej
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
           - platform: windows-latest
             python-version: "3.9"
     env:
+      # We run headless on CI. This yields issues on Mac, where running Java
+      # headless will alter the screen size on Python, leading to errors. Adding
+      # this environment variable prevents Java from modifying the screen size.
       AWT_FORCE_HEADFUL: true
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Operating System :: MacOS
     Operating System :: Microsoft :: Windows
     Operating System :: Unix
     License :: OSI Approved :: BSD License


### PR DESCRIPTION
@ctrueden tested MacOS, documenting that the issues with napari-imagej on Mac seem to only be an issue when running headlessly. Thus this should only be an issue on CI.

This PR attempts his solution at fixing CI.