### PR TITLE
Mutate, but do not return, mutable arguments

### DIFF
--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -2,7 +2,7 @@ from typing import List
 from jpype import JArray, JDouble
 import numpy as np
 from napari_imagej.setup_imagej import ij, jc
-from napari.layers import Labels, Shapes, Points
+from napari.layers import Labels, Shapes, Points, Image
 from napari_imagej import _ntypes
 from scyjava import (
     Converter,
@@ -11,6 +11,12 @@ from scyjava import (
     add_java_converter,
 )
 from labeling.Labeling import Labeling
+
+# -- Image / Img -- #
+
+def _image_to_img(image: Image) -> "jc.Img":
+    data = image.data
+    return ij().py.to_java(data)
 
 
 # -- Labels / ImgLabelings -- #
@@ -306,6 +312,11 @@ def _realpointcollection_to_points(collection):
 
 def _napari_to_java_converters() -> List[Converter]:
     return [
+        Converter(
+            predicate=lambda obj: isinstance(obj, Image),
+            converter=lambda obj: _image_to_img(obj),
+            priority=Priority.VERY_HIGH,
+        ),
         Converter(
             predicate=lambda obj: isinstance(obj, Labels),
             converter=lambda obj: _layer_to_imglabeling(obj),

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -14,6 +14,7 @@ from labeling.Labeling import Labeling
 
 # -- Image / Img -- #
 
+
 def _image_to_img(image: Image) -> "jc.Img":
     data = image.data
     return ij().py.to_java(data)

--- a/src/napari_imagej/_ptypes.py
+++ b/src/napari_imagej/_ptypes.py
@@ -49,9 +49,9 @@ class TypeMappings:
 
         # Images
         self._images = {
-            jc.RandomAccessibleInterval: "napari.types.ImageData",
-            jc.RandomAccessible: "napari.types.ImageData",
-            jc.IterableInterval: "napari.types.ImageData",
+            jc.RandomAccessibleInterval: "napari.layers.Image",
+            jc.RandomAccessible: "napari.layers.Image",
+            jc.IterableInterval: "napari.layers.Image",
             # TODO: remove 'add_legacy=False' -> struggles with LegacyService
             # This change is waiting on a new pyimagej release
             # java_import('ij.ImagePlus'):

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -166,7 +166,7 @@ class DummyModuleItem:
 
 direct_match_pairs = [(jtype, ptype) for jtype, ptype in TypeMappings().ptypes.items()]
 assignable_match_pairs = [
-    (jc.ArrayImg, "napari.types.ImageData")  # ArrayImg -> RAI -> ImageData
+    (jc.ArrayImg, "napari.layers.Image")  # ArrayImg -> RAI -> ImageData
 ]
 convertible_match_pairs = [
     # We want to test that napari could tell that a DoubleArray ModuleItem

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -653,7 +653,7 @@ def run_module_from_script(ij, tmp_path, script):
     _module_utils._preprocess_remaining_inputs(module, [], [], [])
     _module_utils._run_module(module)
     _module_utils._postprocess_module(module)
-    return _module_utils._module_outputs(module)
+    return _module_utils._pure_module_outputs(module)
 
 
 script_zero_layer_zero_widget: str = """

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -797,3 +797,24 @@ def test_non_layer_widget():
         # Assert the value is '1' (stringified 1)
         assert isinstance(subwidget[1], LineEdit)
         assert subwidget[1].value == str(result[1])
+
+
+def test_mutable_layers():
+    # 4 inputs, only the last is a mutable layer
+    unresolved_inputs = [
+        DummyModuleItem(name="a", isOutput=False),
+        DummyModuleItem(name="b", isOutput=True),
+        DummyModuleItem(name="c", isOutput=False),
+        DummyModuleItem(name="d", isOutput=True),
+    ]
+    user_resolved_inputs = [
+        1,
+        2,
+        Image(data=numpy.ones((4, 4))),
+        Image(data=numpy.ones((4, 4))),
+    ]
+    mutable_layers = _module_utils._mutable_layers(
+        unresolved_inputs, user_resolved_inputs
+    )
+    assert 1 == len(mutable_layers)
+    assert user_resolved_inputs[3] in mutable_layers


### PR DESCRIPTION
This PR improves support for preallocated output layers. They were previously returned along with pure outputs to magicgui and napari, showing up as a new layer. With this PR they are no longer returned; instead, `layer.refresh()` is called on each preallocated output layer to ensure the napari view reflects changes made.

For this change to occur, we had to change the type hint of ImgLib2 images to `napari.layers.Image`, from `napari.types.ImageData`. This required the addition of another (trivial) converter to convert those `Image` arguments. We then keep track of any mutable input layers, refreshing them and **not** returning them right before the module finishes up its processing.

Closes #42