### PR TITLE
Remove original ImageJ with add_legacy=False

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches:
       - main
+  
+env:
+  NAPARI_IMAGEJ_TEST_TIMEOUT: 60000
 
 jobs:
   test-pip:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           run: |
-            python -m pytest -p no:faulthandler --color=yes
+            python -m pytest -s -p no:faulthandler --color=yes
 
   ensure-clean-code:
     runs-on: ubuntu-latest
@@ -130,7 +130,7 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           run: |
-            conda run -n napari-imagej-dev python -m pytest -p no:faulthandler --cov-report=xml --cov=.
+            conda run -n napari-imagej-dev --no-capture-output python -m pytest -s -p no:faulthandler --color=yes --cov-report=xml --cov=.
 
       # We could do this in its own action, but we'd have to setup the environment again.
       - name: Upload Coverage to Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,44 +1,23 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
-    hooks:
-      - id: check-docstring-first
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.0
-    hooks:
-      - id: setup-cfg-fmt
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-typing-imports==1.7.0]
+  # First, autoflake the code to avoid issues that could be solved quickly
   - repo: https://github.com/myint/autoflake
     rev: v1.4
     hooks:
       - id: autoflake
         args: ["--in-place", "--remove-all-unused-imports"]
+  # Then, flake
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-typing-imports==1.7.0]
+  # Next, sort imports
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:
       - id: isort
+  # Finally, lint
   - repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
-    hooks:
-      - id: pyupgrade
-        args: [--py37-plus, --keep-runtime-typing]
-  - repo: https://github.com/tlambert03/napari-plugin-checks
-    rev: v0.2.0
-    hooks:
-      - id: napari-plugin-checks
-  # https://mypy.readthedocs.io/en/stable/introduction.html
-  # you may wish to add this as well!
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v0.910-1
-  #   hooks:
-  #     - id: mypy

--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ Once napari-imagej has successfully started ImageJ, the ImageJ2 button at the to
 
 ![Launching the ImageJ2 GUI and transferring data between interfaces](resources/napari_imagej_gui_and_data_transfer.gif)
 
-**Users beware**: Closing the ImageJ2 GUI will dispose the ImageJ2 instance used by PyImageJ. Therefore, *closing the ImageJ2 GUI currently blocks any further usage of **all** napari-imagej functionality.* Once the ImageJ2 GUI has been closed, napari must be restarted to restore napari-imagej functionality.
-
 ## Troubleshooting
 
 ### napari-imagej does not appear in the Plugins menu of napari!
@@ -119,10 +117,6 @@ There are two common cases for a disabled ImageJ2 GUI button:
 1. When napari-imagej is first launched, the button will be disabled until the ImageJ2 Gateway is ready to process data. Please see [here](#The-search-bar-is-disabled-with-the-message-"Initializing-ImageJ...")
 
 2. On some systems (namely **MacOS**), PyImageJ can **only** be run headlessly. In headless PyImageJ environments, the ImageJ2 GUI cannot be launched. Please see [here](https://pyimagej.readthedocs.io/en/latest/Initialization.html#interactive-mode) for more information.
-
-### napari-imagej is not responding to my function calls, searches, ...
-
-The most common cause of such behavior is opening *and then closing* the ImageJ2 GUI. This disposes the ImageJ2 Gateway and prevents any further calls to ImageJ2 functionality. This functionality can only be recovered by restarting napari and napari-imagej. Please see [this issue](https://github.com/imagej/napari-imagej/issues/93) for more discussion.
 
 ## Contributing
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -27,6 +27,7 @@ dependencies:
   - build
   - flake8
   - isort
+  - pre-commit
   - pyqt5-sip
   - pytest
   - pytest-cov

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -14,10 +14,11 @@ channels:
   - defaults
 dependencies:
   # Project dependencies
-  - napari
-  - magicgui >= 0.5.1
-  - pyimagej >= 1.2.0
   - labeling >= 0.1.12
+  - magicgui >= 0.5.1
+  - napari
+  - openjdk=8
+  - pyimagej >= 1.2.0
   # Test dependencies
   - numpy
   # Developer tools

--- a/environment.yml
+++ b/environment.yml
@@ -14,10 +14,11 @@ channels:
   - defaults
 dependencies:
   # Project depenencies
-  - napari
-  - magicgui >= 0.5.1
-  - pyimagej >= 1.2.0
   - labeling >= 0.1.12
+  - magicgui >= 0.5.1
+  - napari
+  - openjdk=8
+  - pyimagej >= 1.2.0
   # Project from source
   - pip
   - pip:

--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -258,6 +258,11 @@ def _preprocess_remaining_inputs(
     for module_item, input in zip(unresolved_inputs, resolved_java_args):
         _resolve_user_input(module, module_item, input)
 
+    # Deliberately ignore optional inputs
+    for input in inputs:
+        if not input.isRequired() and not module.isInputResolved(input.getName()):
+            module.resolveInput(input.getName())
+
     for processor in remaining_preprocessors:
         processor.process(module)
 

--- a/src/napari_imagej/setup_imagej.py
+++ b/src/napari_imagej/setup_imagej.py
@@ -39,7 +39,8 @@ def imagej_init():
     )
     config.add_option(f"-Dimagej2.dir={os.getcwd()}")  # TEMP
     config.endpoints.append("io.scif:scifio:0.43.1")
-    config.endpoints.append("org.scijava:scijava-common:2.89.0")  # TEMP
+    # TODO: Remove this once net.imagej:imagej:2.6.0 and sc.fiji:fiji:2.6.0 released
+    config.endpoints.append("org.scijava:scijava-common:2.89.0")
     log_debug("Completed JVM Configuration")
 
     # Configure PyImageJ settings

--- a/src/napari_imagej/setup_imagej.py
+++ b/src/napari_imagej/setup_imagej.py
@@ -44,7 +44,9 @@ def imagej_init():
     # Parse imagej settings
     ij_dir = setting("imagej_installation")
 
-    _ij = imagej.init(ij_dir_or_version_or_endpoint=ij_dir, mode=get_mode())
+    _ij = imagej.init(
+        ij_dir_or_version_or_endpoint=ij_dir, mode=get_mode(), add_legacy=False
+    )
     log_debug(f"Initialized at version {_ij.getVersion()}")
 
     # Final configuration

--- a/src/napari_imagej/setup_imagej.py
+++ b/src/napari_imagej/setup_imagej.py
@@ -74,7 +74,7 @@ def _disable_jvm_shutdown_on_gui_quit(ij_instance):
         ij_instance.IJ.getInstance().exitWhenQuitting(False)
     # Prevent quitting from the ImageJ2 GUI
     else:
-        raise NotImplementedError("Cannot yet block quitting of ImageJ2")
+        log_debug("Cannot yet block quitting of ImageJ2!")
 
 
 def get_mode() -> str:

--- a/src/napari_imagej/setup_imagej.py
+++ b/src/napari_imagej/setup_imagej.py
@@ -42,12 +42,15 @@ def imagej_init():
     config.endpoints.append("org.scijava:scijava-common:2.89.0")  # TEMP
     log_debug("Completed JVM Configuration")
 
-    # Parse imagej settings
-    ij_dir = setting("imagej_installation")
+    # Configure PyImageJ settings
+    settings = {
+        "ij_dir_or_version_or_endpoint": setting("imagej_installation"),
+        "mode": get_mode(),
+        "add_legacy": False,
+    }
 
-    _ij = imagej.init(
-        ij_dir_or_version_or_endpoint=ij_dir, mode=get_mode(), add_legacy=False
-    )
+    # Launch PyImageJ
+    _ij = imagej.init(**settings)
     log_debug(f"Initialized at version {_ij.getVersion()}")
 
     # Return the ImageJ gateway

--- a/src/napari_imagej/setup_imagej.py
+++ b/src/napari_imagej/setup_imagej.py
@@ -39,8 +39,6 @@ def imagej_init():
     )
     config.add_option(f"-Dimagej2.dir={os.getcwd()}")  # TEMP
     config.endpoints.append("io.scif:scifio:0.43.1")
-    # TODO: Remove this once net.imagej:imagej:2.6.0 and sc.fiji:fiji:2.6.0 released
-    config.endpoints.append("org.scijava:scijava-common:2.89.0")
     log_debug("Completed JVM Configuration")
 
     # Configure PyImageJ settings

--- a/src/napari_imagej/setup_imagej.py
+++ b/src/napari_imagej/setup_imagej.py
@@ -39,6 +39,7 @@ def imagej_init():
     )
     config.add_option(f"-Dimagej2.dir={os.getcwd()}")  # TEMP
     config.endpoints.append("io.scif:scifio:0.43.1")
+    config.endpoints.append("org.scijava:scijava-common:2.89.0")  # TEMP
     log_debug("Completed JVM Configuration")
 
     # Parse imagej settings
@@ -48,9 +49,6 @@ def imagej_init():
         ij_dir_or_version_or_endpoint=ij_dir, mode=get_mode(), add_legacy=False
     )
     log_debug(f"Initialized at version {_ij.getVersion()}")
-
-    # Final configuration
-    _disable_jvm_shutdown_on_gui_quit(_ij)
 
     # Return the ImageJ gateway
     return _ij
@@ -63,18 +61,6 @@ def setting(value: str):
 @lru_cache(maxsize=None)
 def settings():
     return yaml.safe_load(open("settings.yml", "r"))
-
-
-def _disable_jvm_shutdown_on_gui_quit(ij_instance):
-    # We can't quit the gui running headlessly!
-    if running_headless():
-        return
-    # Prevent quitting from the ImageJ Legacy GUI
-    if ij_instance.legacy and ij_instance.legacy.isActive():
-        ij_instance.IJ.getInstance().exitWhenQuitting(False)
-    # Prevent quitting from the ImageJ2 GUI
-    else:
-        log_debug("Cannot yet block quitting of ImageJ2!")
 
 
 def get_mode() -> str:
@@ -237,6 +223,10 @@ class JavaClasses(object):
     def Path(self):
         return "java.nio.file.Path"
 
+    @blocking_import
+    def Window(self):
+        return "java.awt.Window"
+
     # SciJava Types
 
     @blocking_import
@@ -294,6 +284,14 @@ class JavaClasses(object):
     @blocking_import
     def Types(self):
         return "org.scijava.util.Types"
+
+    @blocking_import
+    def UIComponent(self):
+        return "org.scijava.widget.UIComponent"
+
+    @blocking_import
+    def UserInterface(self):
+        return "org.scijava.ui.UserInterface"
 
     # ImgLib2 Types
 

--- a/src/napari_imagej/widget_IJ2.py
+++ b/src/napari_imagej/widget_IJ2.py
@@ -48,7 +48,8 @@ class GUIWidget(QWidget):
         NB: This must be its own function to prevent premature calling of ij()
         """
         ensure_jvm_started()
-        ij().ui().showUI()
+        if not ij().ui().isVisible():
+            ij().ui().showUI()
 
 
 class ToIJButton(QPushButton):

--- a/src/napari_imagej/widget_IJ2.py
+++ b/src/napari_imagej/widget_IJ2.py
@@ -2,6 +2,7 @@ from enum import Enum
 from threading import Thread
 from typing import Optional
 
+from jpype import JImplements, JOverride
 from magicgui.widgets import request_values
 from napari import Viewer
 from napari._qt.qt_resources import QColoredSVGIcon
@@ -43,13 +44,77 @@ class GUIWidget(QWidget):
             self.gui_button.clicked.connect(lambda: self.to_ij.setEnabled(True))
             self.gui_button.clicked.connect(lambda: self.from_ij.setEnabled(True))
 
+    @property
+    def gui(self) -> "jc.UserInterface":
+        ensure_jvm_started()
+        return ij().ui().getDefaultUI()
+
     def _showUI(self):
         """
         NB: This must be its own function to prevent premature calling of ij()
         """
         ensure_jvm_started()
-        if not ij().ui().isVisible():
-            ij().ui().showUI()
+        # First time showing
+        if not self.gui.isVisible():
+            # First things first, show the GUI
+            ij().ui().showUI(self.gui)
+            # Then, add our custom settings to the User Interface
+            if ij().legacy and ij().legacy.isActive():
+                self._ij1_UI_setup()
+            else:
+                self._ij2_UI_setup()
+        # Later shows - the GUI is "visible", but the appFrame probably isn't
+        else:
+            self.gui.getApplicationFrame().setVisible(True)
+
+    def _ij1_UI_setup(self):
+        ij().IJ.getInstance().exitWhenQuitting(False)
+
+    def _ij2_UI_setup(self):
+        appFrame = self.gui.getApplicationFrame()
+        # Overwrite the WindowListeners so we control closing behavior
+        if isinstance(appFrame, jc.Window):
+            self._kill_window_listeners(appFrame)
+        elif isinstance(appFrame, jc.UIComponent):
+            self._kill_window_listeners(appFrame.getComponent())
+
+    def _kill_window_listeners(self, window):
+        # Remove all preset WindowListeners
+        for listener in window.getWindowListeners():
+            window.removeWindowListener(listener)
+
+        # Add our own behavior for WindowEvents
+        @JImplements("java.awt.event.WindowListener")
+        class NapariAdapter(object):
+            @JOverride
+            def windowOpened(self, event):
+                pass
+
+            @JOverride
+            def windowClosing(self, event):
+                window.setVisible(False)
+
+            @JOverride
+            def windowClosed(self, event):
+                pass
+
+            @JOverride
+            def windowIconified(self, event):
+                pass
+
+            @JOverride
+            def windowDeiconified(self, event):
+                pass
+
+            @JOverride
+            def windowActivated(self, event):
+                pass
+
+            @JOverride
+            def windowDeactivated(self, event):
+                pass
+
+        window.addWindowListener(NapariAdapter())
 
 
 class ToIJButton(QPushButton):

--- a/src/napari_imagej/widget_IJ2.py
+++ b/src/napari_imagej/widget_IJ2.py
@@ -46,6 +46,7 @@ class GUIWidget(QWidget):
 
     @property
     def gui(self) -> "jc.UserInterface":
+        """Convenience function for obtaining the default UserInterface"""
         ensure_jvm_started()
         return ij().ui().getDefaultUI()
 
@@ -68,9 +69,11 @@ class GUIWidget(QWidget):
             self.gui.getApplicationFrame().setVisible(True)
 
     def _ij1_UI_setup(self):
+        """Configures the ImageJ Legacy GUI"""
         ij().IJ.getInstance().exitWhenQuitting(False)
 
     def _ij2_UI_setup(self):
+        """Configures the ImageJ2 Swing GUI"""
         appFrame = self.gui.getApplicationFrame()
         # Overwrite the WindowListeners so we control closing behavior
         if isinstance(appFrame, jc.Window):
@@ -79,6 +82,7 @@ class GUIWidget(QWidget):
             self._kill_window_listeners(appFrame.getComponent())
 
     def _kill_window_listeners(self, window):
+        """Replaces the WindowListeners present on window with our own"""
         # Remove all preset WindowListeners
         for listener in window.getWindowListeners():
             window.removeWindowListener(listener)
@@ -92,6 +96,7 @@ class GUIWidget(QWidget):
 
             @JOverride
             def windowClosing(self, event):
+                # We don't want to shut down anything, we just want to hide the window.
                 window.setVisible(False)
 
             @JOverride

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from napari_imagej.widget_IJ2 import GUIWidget
 
 @pytest.fixture(scope="module")
 def ij():
+    """Fixture providing the ImageJ2 Gateway"""
     from napari_imagej.setup_imagej import ij
 
     return ij()
@@ -18,11 +19,13 @@ def ij():
 
 @pytest.fixture()
 def viewer(make_napari_viewer) -> Generator[Viewer, None, None]:
+    """Fixture providing a napari Viewer"""
     yield make_napari_viewer()
 
 
 @pytest.fixture
 def imagej_widget(viewer) -> Generator[ImageJWidget, None, None]:
+    """Fixture providing an ImageJWidget"""
     # Create widget
     ij_widget: ImageJWidget = ImageJWidget(viewer)
 
@@ -34,6 +37,12 @@ def imagej_widget(viewer) -> Generator[ImageJWidget, None, None]:
 
 @pytest.fixture
 def gui_widget(viewer) -> Generator[GUIWidget, None, None]:
+    """
+    Fixture providing a GUIWidget. The returned widget will use active layer selection
+    """
+
+    # Define GUIWidget settings for this particular feature.
+    # In particular, we want to enforce active layer selection
     def mock_setting(value: str):
         return {"imagej_installation": None, "choose_active_layer": True}[value]
 
@@ -50,8 +59,12 @@ def gui_widget(viewer) -> Generator[GUIWidget, None, None]:
 
 @pytest.fixture
 def gui_widget_chooser(viewer) -> Generator[GUIWidget, None, None]:
+    """
+    Fixture providing a GUIWidget. The returned widget will use user layer selection
+    """
 
-    # monkeypatch settings
+    # Define GUIWidget settings for this particular feature.
+    # In particular, we want to enforce user layer selection via Dialog
     def mock_setting(value: str):
         return {"imagej_installation": None, "choose_active_layer": False}[value]
 
@@ -68,13 +81,18 @@ def gui_widget_chooser(viewer) -> Generator[GUIWidget, None, None]:
 
 @pytest.fixture()
 def asserter(qtbot) -> Callable[[Callable[[], bool]], None]:
+    """Wraps qtbot.waitUntil with a standardized timeout"""
+
+    # Determine timeout length
     if "NAPARI_IMAGEJ_TEST_TIMEOUT" in os.environ:
         timeout = int(os.environ["NAPARI_IMAGEJ_TEST_TIMEOUT"])
     else:
         timeout = 5000  # 5 seconds
 
+    # Define timeout function
     def assertFunc(func: Callable[[], bool]):
         # Let things run for up to a minute
         qtbot.waitUntil(func, timeout=timeout)
 
+    # Return the timeout function
     return assertFunc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,10 +20,6 @@ def viewer(make_napari_viewer) -> Generator[Viewer, None, None]:
     yield make_napari_viewer()
 
 
-# HACK: Something about the ImageJ2 GUI causes these unit tests to hang.
-# Let's force it to close, for now.
-
-
 @pytest.fixture
 def imagej_widget(viewer) -> Generator[ImageJWidget, None, None]:
     # Create widget

--- a/tests/test_IJ2GUIWidget.py
+++ b/tests/test_IJ2GUIWidget.py
@@ -31,11 +31,14 @@ jc = JavaClassesTest()
 
 @pytest.fixture(autouse=True)
 def napari_mocker(viewer: Viewer):
+    """Fixture allowing the mocking of napari utilities"""
+
+    # REQUEST_VALUES MOCK
     oldfunc = widget_IJ2.request_values
 
-    # A HACK-y mock for widgets.request_values
     def newfunc(values=(), title="", **kwargs):
         results = {}
+        # Solve each parameter
         for name, options in kwargs.items():
             if "choices" in options["options"]:
                 if options["annotation"] == Layer:
@@ -46,8 +49,8 @@ def napari_mocker(viewer: Viewer):
 
                 continue
 
+            # Otherwise, we don't know how to solve that parameter
             raise NotImplementedError()
-
         return results
 
     widget_IJ2.request_values = newfunc
@@ -59,6 +62,7 @@ def napari_mocker(viewer: Viewer):
 
 @pytest.fixture(autouse=True)
 def clean_layers_and_Displays(asserter, ij, viewer: Viewer):
+    """Fixture to remove image data from napari and ImageJ2"""
 
     # Test pre-processing
 

--- a/tests/test_ImageJWidget.py
+++ b/tests/test_ImageJWidget.py
@@ -90,18 +90,8 @@ def test_button_param_regression(ij, imagej_widget: ImageJWidget):
         imagej_widget.focuser.tooltips[py_actions[1][0]]
         == "Runs functionality from a napari widget. Useful for parameter sweeping"
     )
-    assert py_actions[2].name == "Help"
-    assert (
-        imagej_widget.focuser.tooltips[py_actions[2][0]]
-        == "Opens the functionality's ImageJ.net wiki page"
-    )
-    assert py_actions[3].name == "Source"
-    assert (
-        imagej_widget.focuser.tooltips[py_actions[3][0]]
-        == "Opens the source code on GitHub"
-    )
-    assert py_actions[4].name == "Batch"
-    assert py_actions[4].name not in imagej_widget.focuser.tooltips
+    assert py_actions[2].name == "Batch"
+    assert py_actions[2].name not in imagej_widget.focuser.tooltips
 
 
 def test_keymaps(make_napari_viewer, qtbot):

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -693,10 +693,6 @@ def run_module_from_script(ij, tmp_path, script):
     return _module_utils._pure_module_outputs(module, unresolved_inputs)
 
 
-#     module = ij.py.run_script(language="Groovy", script=script, args=[])
-#     return _module_utils._module_outputs(module)
-
-
 script_zero_layer_zero_widget: str = """
 c = 1
 """

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -693,6 +693,10 @@ def run_module_from_script(ij, tmp_path, script):
     return _module_utils._pure_module_outputs(module, unresolved_inputs)
 
 
+#     module = ij.py.run_script(language="Groovy", script=script, args=[])
+#     return _module_utils._module_outputs(module)
+
+
 script_zero_layer_zero_widget: str = """
 c = 1
 """

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -674,7 +674,7 @@ def test_modify_functional_signature():
     assert sig.return_annotation is None
 
 
-def run_module_from_script(ij, tmp_path, script):
+def run_module_from_script(ij, tmp_path, script, args):
     # Write the script to a file
     p = tmp_path / "script.py"
     p.write_text(script)
@@ -683,13 +683,17 @@ def run_module_from_script(ij, tmp_path, script):
     module = info.createModule()
     ij.context().inject(module)
     remaining_preprocessors = _module_utils._preprocess_to_harvester(module)
-    _module_utils._preprocess_remaining_inputs(
-        module, [], [], [], remaining_preprocessors
-    )
-    _module_utils._run_module(module)
-    _module_utils._postprocess_module(module)
+    # Find all unresolved inputs
     unresolved_inputs = _module_utils._filter_unresolved_inputs(module, info.inputs())
     unresolved_inputs = _module_utils._sink_optional_inputs(unresolved_inputs)
+    # Resolve the inputs
+    _module_utils._preprocess_remaining_inputs(
+        module, info.inputs(), unresolved_inputs, args, remaining_preprocessors
+    )
+    # Run the module
+    _module_utils._run_module(module)
+    _module_utils._postprocess_module(module)
+    # Return the outputs
     return _module_utils._pure_module_outputs(module, unresolved_inputs)
 
 
@@ -791,27 +795,27 @@ from net.imglib2.img.array import ArrayImgs
 """
 
 widget_parameterizations = [
-    (script_zero_layer_zero_widget, 0, 0),
-    (script_one_layer_zero_widget, 1, 0),
-    (script_two_layer_zero_widget, 2, 0),
-    (script_zero_layer_one_widget, 0, 1),
-    (script_one_layer_one_widget, 1, 1),
-    (script_two_layer_one_widget, 2, 1),
-    (script_zero_layer_two_widget, 0, 2),
-    (script_one_layer_two_widget, 1, 2),
-    (script_two_layer_two_widget, 2, 2),
+    (script_zero_layer_zero_widget, 0, 0, []),
+    (script_one_layer_zero_widget, 1, 0, []),
+    (script_two_layer_zero_widget, 2, 0, []),
+    (script_zero_layer_one_widget, 0, 1, []),
+    (script_one_layer_one_widget, 1, 1, []),
+    (script_two_layer_one_widget, 2, 1, []),
+    (script_zero_layer_two_widget, 0, 2, []),
+    (script_one_layer_two_widget, 1, 2, []),
+    (script_two_layer_two_widget, 2, 2, []),
     # No layers returned, the required BOTH is just updated
-    (script_both_but_required, 0, 0),
+    (script_both_but_required, 0, 0, [jc.ArrayImgs.bytes(10, 10)]),
     # One layer returned as we create the optional input internally
-    (script_both_but_optional, 1, 0),
+    (script_both_but_optional, 1, 0, []),
 ]
 
 
 @pytest.mark.parametrize(
-    argnames="script, num_layer, num_widget", argvalues=widget_parameterizations
+    argnames="script, num_layer, num_widget, args", argvalues=widget_parameterizations
 )
-def test_module_outputs_number(ij, tmp_path, script, num_layer, num_widget):
-    layer_outputs, widget_outputs = run_module_from_script(ij, tmp_path, script)
+def test_module_outputs_number(ij, tmp_path, script, num_layer, num_widget, args):
+    layer_outputs, widget_outputs = run_module_from_script(ij, tmp_path, script, args)
     if num_layer == 0:
         assert layer_outputs is None
     else:


### PR DESCRIPTION
As noted by @ctrueden in #45, this will increase available functionality.

This PR is a draft because the removal of imagej-legacy also removes the dependency on `scijava-script`, which breaks tests.

Closes #45