### PR TITLE
Ship example script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ venv/
 # written by setuptools_scm
 **/_version.py
 
+# Scripts
+/scripts/*
+!/scripts/examples

--- a/scripts/examples/Example_Script.js
+++ b/scripts/examples/Example_Script.js
@@ -1,0 +1,70 @@
+#@ boolean (label="boolean") pBoolean
+#@ byte (label="byte") pByte
+#@ char (label="char") pChar
+#@ double (label="double") pDouble
+#@ float (label="float") pFloat
+#@ int (label="int") pInt
+#@ long (label="long") pLong
+#@ short (label="short") pShort
+#@ Boolean (label="Boolean") oBoolean
+#@ Byte (label="Byte") oByte
+#@ Character (label="Character") oCharacter
+#@ Double (label="Double") oDouble
+#@ Float (label="Float") oFloat
+#@ Integer (label="Integer") oInteger
+#@ Long (label="Long") oLong
+#@ Short (label="Short") oShort
+#@ int (min=0, max=1000) boundedInteger
+#@ double (min=0.2, max=1000.7, stepSize=12.34) boundedDouble
+#@ BigInteger bigInteger
+#@ BigDecimal bigDecimal
+#@ String string
+#@ File file
+// Colors aren't supported - see https://github.com/imagej/napari-imagej/issues/62
+// #@ ColorRGB color
+#@output String result
+
+// A JavaScript script exercising various parameter types.
+// It is the duty of the scripting framework to harvest
+// the parameter values from the user, and then display
+// the 'result' output parameter, based on its type.
+
+var sb = new java.lang.StringBuilder();
+
+sb.append("Widgets JavaScript results:\n");
+
+sb.append("\n");
+sb.append("\tboolean = " + pBoolean + "\n");
+sb.append("\tbyte = " + pByte + "\n");
+sb.append("\tchar = " + "'" + pChar + "' [" + pChar.charCodeAt(0) + "]\n");
+sb.append("\tdouble = " + pDouble + "\n");
+sb.append("\tfloat = " + pFloat + "\n");
+sb.append("\tint = " + pInt + "\n");
+sb.append("\tlong = " + pLong + "\n");
+sb.append("\tshort = " + pShort + "\n");
+
+sb.append("\n");
+sb.append("\tBoolean = " + oBoolean + "\n");
+sb.append("\tByte = " + oByte + "\n");
+oCharValue = oCharacter == null ? "null" : "" + oCharacter.charCodeAt(0);
+sb.append("\tCharacter = " + "'" + oCharacter + "' [" + oCharValue + "]\n");
+sb.append("\tDouble = " + oDouble + "\n");
+sb.append("\tFloat = " + oFloat + "\n");
+sb.append("\tInteger = " + oInteger + "\n");
+sb.append("\tLong = " + oLong + "\n");
+sb.append("\tShort = " + oShort + "\n");
+
+sb.append("\n");
+sb.append("\tbounded integer = " + boundedInteger + "\n");
+sb.append("\tbounded double = " + boundedDouble + "\n");
+
+sb.append("\n");
+sb.append("\tBigInteger = " + bigInteger + "\n");
+sb.append("\tBigDecimal = " + bigDecimal + "\n");
+sb.append("\tString = " + string + "\n");
+sb.append("\tFile = " + file + "\n");
+// Colors aren't supported - see https://github.com/imagej/napari-imagej/issues/62
+// sb.append("\tcolor = " + color + "\n");
+
+result = sb.toString();
+

--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -166,13 +166,22 @@ def _widget_return_type(module_info: "jc.Module") -> type:
 
 
 def _preprocess_to_harvester(module) -> List["jc.PreprocessorPlugin"]:
-    """Uses all preprocessors up to the InputHarvesters."""
-    # preprocess using plugin preprocessors
-    log_debug("Preprocessing...")
-    preprocessors = ij().plugin().createInstancesOfType(jc.PreprocessorPlugin)
+    """
+    Uses all preprocessors up to the InputHarvesters.
+    We stop at the InputHarvesters as they would attempt to resolve inputs that
+    we want to resolve in napari.
 
+    We return the list of preprocessors that HAVE NOT YET RUN, so the calling code
+    can run them later.
+
+    :param module: The module to preprocess
+    :return: The list of preprocessors that have not yet run.
+    """
+    log_debug("Preprocessing...")
+
+    preprocessors = ij().plugin().createInstancesOfType(jc.PreprocessorPlugin)
     for i, preprocessor in enumerate(preprocessors):
-        # if preprocessor is an InputHarvester, we need to stop.
+        # if preprocessor is an InputHarvester, stop and return the remaining list
         if isinstance(preprocessor, jc.InputHarvester):
             return list(preprocessors)[i:]
         # preprocess

--- a/src/napari_imagej/_ptypes.py
+++ b/src/napari_imagej/_ptypes.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 from typing import Dict, List
+
+from jpype import JBoolean, JByte, JChar, JDouble, JFloat, JInt, JLong, JShort
 from napari_imagej.setup_imagej import jc
 
 
@@ -15,6 +17,7 @@ class TypeMappings:
 
         # Strings
         self._strings = {
+            JChar: str,
             jc.Character_Arr: str,
             jc.Character: str,
             jc.String: str,
@@ -22,6 +25,7 @@ class TypeMappings:
 
         # Booleans
         self._booleans = {
+            JBoolean: bool,
             jc.Boolean_Arr: List[bool],
             jc.Boolean: bool,
             jc.BooleanType: bool,
@@ -29,16 +33,22 @@ class TypeMappings:
 
         # Numbers
         self._numbers = {
+            JByte: int,
             jc.Byte: int,
             jc.Byte_Arr: List[int],
+            JShort: int,
             jc.Short: int,
             jc.Short_Arr: List[int],
+            JInt: int,
             jc.Integer: int,
             jc.Integer_Arr: List[int],
+            JLong: int,
             jc.Long: int,
             jc.Long_Arr: List[int],
+            JFloat: float,
             jc.Float: float,
             jc.Float_Arr: List[float],
+            JDouble: float,
             jc.Double: float,
             jc.Double_Arr: List[float],
             jc.BigInteger: int,

--- a/src/napari_imagej/setup_imagej.py
+++ b/src/napari_imagej/setup_imagej.py
@@ -33,7 +33,7 @@ def imagej_init():
     config.add_repositories(
         {"scijava.public": "https://maven.scijava.org/content/groups/public"}
     )
-    config.add_option(f"-Dimagej.dir={os.getcwd()}")  # TEMP
+    config.add_option(f"-Dimagej2.dir={os.getcwd()}")  # TEMP
     config.endpoints.append("io.scif:scifio:0.43.1")
 
     log_debug("Completed JVM Configuration")
@@ -197,6 +197,10 @@ class JavaClasses(object):
     @blocking_import
     def DisplayPostprocessor(self):
         return "org.scijava.module.process.PostprocessorPlugin"
+
+    @blocking_import
+    def InputHarvester(self):
+        return "org.scijava.widget.InputHarvester"
 
     @blocking_import
     def Module(self):

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -1,0 +1,32 @@
+from magicgui import magicgui
+from napari_imagej._module_utils import functionify_module_execution
+from napari_imagej.setup_imagej import JavaClasses
+
+
+class JavaClassesTest(JavaClasses):
+    """
+    Here we override JavaClasses to get extra test imports
+    """
+
+    @JavaClasses.blocking_import
+    def DefaultModuleService(self):
+        return "org.scijava.module.DefaultModuleService"
+
+
+jc = JavaClassesTest()
+
+
+def test_example_script_exists(ij):
+    """
+    Asserts that Example_Script.js in the local scripts/examples directory can be found
+    from the module service, AND that it can be converted into a magicgui widget.
+    """
+    module_info = ij.module().getModuleById("script:examples/Example_Script.js")
+    assert module_info is not None
+
+    module = ij.module().createModule(module_info)
+
+    func, magic_kwargs = functionify_module_execution(None, module, module_info)
+
+    # Normally we'd assign the call to a variable, but we aren't using it..
+    magicgui(function=func, **magic_kwargs)


### PR DESCRIPTION
This PR ensures the ability of ImageJ to discover scripts located *within a subfolder* of the `scripts` directory. An example script `scripts/example/Example_Script.js` is shipped within this new directory and a test ensures this script can be retrieved from the `ModuleService`.

This PR also adds support in `_module_utils.python_type_of` for Java primtives; this support was somehow missing.


Closes #59