### PR TITLE
Add Github Action for isort

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,24 +78,24 @@ jobs:
         run: |
           python -m pytest -p no:faulthandler --color=yes
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: psf/black@stable
-
-  flake:
+  ensure-clean-code:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
-      - name: flake src code
+
+      - name: Lint code
+        uses: psf/black@stable
+
+      - name: Flake code
         run: |
           python -m pip install flake8
-          python -m flake8 src
-      - name: flake test code
-        run: |
-          python -m flake8 tests
+          python -m flake8 src tests
+
+      - name: Check import ordering
+        uses: isort/isort-action@master
+        with:
+          configuration: --check-only
 
   conda-dev-test:
     name: Conda Setup & Code Coverage

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -25,6 +25,7 @@ dependencies:
   - black
   - build
   - flake8
+  - isort
   - pyqt5-sip
   - pytest
   - pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ requires = [
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.isort]
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ dev =
     black
     build
     flake8
+    isort
     pyqt5
     pytest
     pytest-cov

--- a/src/napari_imagej/__init__.py
+++ b/src/napari_imagej/__init__.py
@@ -1,7 +1,8 @@
 __version__ = "0.0.1.dev0"
 
-from napari_imagej._napari_converters import init_napari_converters
 from scyjava import when_jvm_starts
+
+from napari_imagej._napari_converters import init_napari_converters
 
 # Install napari <-> java converters
 when_jvm_starts(init_napari_converters)

--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -1,13 +1,15 @@
 from functools import lru_cache
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
-from scyjava import Priority, JavaIterable, JavaMap, JavaSet
 from inspect import Parameter, Signature, signature
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
+
+from magicgui.widgets import Container, Label, LineEdit, Widget
 from napari import Viewer
 from napari.layers import Layer
 from napari.types import LayerDataTuple
+from scyjava import JavaIterable, JavaMap, JavaSet, Priority
+
 from napari_imagej._ptypes import TypeMappings, _supported_styles
 from napari_imagej.setup_imagej import ij, jc, log_debug
-from magicgui.widgets import Widget, Container, Label, LineEdit
 
 
 @lru_cache(maxsize=None)

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -1,16 +1,13 @@
 from typing import List
-from jpype import JArray, JDouble
+
 import numpy as np
-from napari_imagej.setup_imagej import ij, jc
-from napari.layers import Labels, Shapes, Points, Image
-from napari_imagej import _ntypes
-from scyjava import (
-    Converter,
-    Priority,
-    add_py_converter,
-    add_java_converter,
-)
+from jpype import JArray, JDouble
 from labeling.Labeling import Labeling
+from napari.layers import Image, Labels, Points, Shapes
+from scyjava import Converter, Priority, add_java_converter, add_py_converter
+
+from napari_imagej import _ntypes
+from napari_imagej.setup_imagej import ij, jc
 
 # -- Image / Img -- #
 

--- a/src/napari_imagej/_ntypes.py
+++ b/src/napari_imagej/_ntypes.py
@@ -1,5 +1,5 @@
-from napari.layers import Labels
 from labeling.Labeling import Labeling
+from napari.layers import Labels
 
 
 def _labeling_to_layer(labeling: Labeling):

--- a/src/napari_imagej/_ptypes.py
+++ b/src/napari_imagej/_ptypes.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from typing import Dict, List
 
 from jpype import JBoolean, JByte, JChar, JDouble, JFloat, JInt, JLong, JShort
+
 from napari_imagej.setup_imagej import jc
 
 

--- a/src/napari_imagej/setup_imagej.py
+++ b/src/napari_imagej/setup_imagej.py
@@ -1,10 +1,11 @@
-import os
-from typing import Callable
-from jpype import JClass
 import logging
-import imagej
-from scyjava import config, jimport
+import os
 from multiprocessing.pool import AsyncResult, ThreadPool
+from typing import Callable
+
+import imagej
+from jpype import JClass
+from scyjava import config, jimport
 
 # -- LOGGER CONFIG -- #
 

--- a/src/napari_imagej/widget.py
+++ b/src/napari_imagej/widget.py
@@ -7,23 +7,25 @@ see: https://napari.org/docs/dev/plugins/hook_specifications.html
 Replace code below according to your needs.
 """
 from functools import lru_cache
+from threading import Thread
 from typing import List
+
 from napari import Viewer
 from qtpy.QtWidgets import (
-    QWidget,
-    QHBoxLayout,
-    QVBoxLayout,
-    QPushButton,
-    QLineEdit,
-    QTableWidget,
     QAbstractItemView,
+    QHBoxLayout,
     QHeaderView,
-    QTableWidgetItem,
     QLabel,
+    QLineEdit,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
 )
-from napari_imagej.setup_imagej import ensure_jvm_started, ij, jc, log_debug
+
 from napari_imagej._module_utils import functionify_module_execution
-from threading import Thread
+from napari_imagej.setup_imagej import ensure_jvm_started, ij, jc, log_debug
 
 
 class ImageJWidget(QWidget):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 from typing import Generator
+
 import pytest
+from napari import Viewer
 
 from napari_imagej.widget import ImageJWidget
-from napari import Viewer
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_ImageJWidget.py
+++ b/tests/test_ImageJWidget.py
@@ -1,17 +1,18 @@
+from qtpy.QtWidgets import (
+    QAbstractItemView,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QTableWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
 from napari_imagej.widget import (
     FocusWidget,
     ImageJWidget,
     ResultsWidget,
     SearchbarWidget,
-)
-from qtpy.QtWidgets import (
-    QWidget,
-    QVBoxLayout,
-    QHBoxLayout,
-    QTableWidget,
-    QAbstractItemView,
-    QLineEdit,
-    QLabel,
 )
 
 

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -1,25 +1,26 @@
+from inspect import Parameter, _empty
 from typing import Any, Dict, List, Optional
+
+import numpy
+import pytest
 from magicgui.widgets import (
-    Widget,
     Container,
+    FloatSlider,
+    FloatSpinBox,
     Label,
     LineEdit,
-    Select,
     RadioButtons,
+    Select,
     Slider,
-    FloatSlider,
     SpinBox,
-    FloatSpinBox,
+    Widget,
 )
-
-import pytest
-import numpy
-from napari.layers import Layer, Shapes, Points, Image, Labels
+from napari.layers import Image, Labels, Layer, Points, Shapes
 from napari.types import LayerDataTuple
-from inspect import Parameter, _empty
+
 from napari_imagej import _module_utils
-from napari_imagej.setup_imagej import JavaClasses
 from napari_imagej._ptypes import TypeMappings, _supported_styles
+from napari_imagej.setup_imagej import JavaClasses
 
 
 class JavaClassesTest(JavaClasses):

--- a/tests/test_napari_converters.py
+++ b/tests/test_napari_converters.py
@@ -1,10 +1,12 @@
 from typing import Any, Dict, List
-from jpype import JArray, JDouble
-import pytest
+
 import numpy as np
-from napari_imagej._ntypes import _labeling_to_layer, _layer_to_labeling
+import pytest
+from jpype import JArray, JDouble
 from labeling.Labeling import Labeling
-from napari.layers import Labels, Shapes, Points
+from napari.layers import Labels, Points, Shapes
+
+from napari_imagej._ntypes import _labeling_to_layer, _layer_to_labeling
 from napari_imagej.setup_imagej import jc
 
 

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -1,4 +1,5 @@
 from magicgui import magicgui
+
 from napari_imagej._module_utils import functionify_module_execution
 from napari_imagej.setup_imagej import JavaClasses
 


### PR DESCRIPTION
While it *says* that I added an action, I actually decided to remove one, and squash all "formatting" checks into a single action `ensure-clean-code`!

This PR formats the `import` statements to use [`isort`](https://github.com/PyCQA/isort)