### PR TITLE
Add a New Image Button for preallocated outputs

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -15,7 +15,7 @@ channels:
 dependencies:
   # Project dependencies
   - napari
-  - magicgui >= 0.4.0
+  - magicgui >= 0.5.1
   - pyimagej >= 1.2.0
   - labeling >= 0.1.12
   # Test dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ channels:
 dependencies:
   # Project depenencies
   - napari
-  - magicgui >= 0.4.0
+  - magicgui >= 0.5.1
   - pyimagej >= 1.2.0
   - labeling >= 0.1.12
   # Project from source

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ package_dir =
 install_requires =
     labeling >= 0.1.12
     napari
-    magicgui >= 0.4.0
+    magicgui >= 0.5.1
     pyimagej >= 1.2.0
 
 [options.packages.find]

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -36,7 +36,6 @@ class MutableOutputWidget(Container):
         self.new_btn = PushButton(text="New")
         self.new_btn.max_width = 53
         self._nullable = nullable
-        self.kwargs = kwargs
         kwargs["widgets"] = [self.new_btn, self.layer_select]
         kwargs["labels"] = False
         kwargs["layout"] = "horizontal"

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -34,22 +34,22 @@ class MutableOutputWidget(Container):
             value = ""
 
         self.layer_select = ComboBox(choices=choices, **kwargs)
-        self.choose_btn = PushButton(text="New")
-        self.choose_btn.max_width = 53
+        self.new_btn = PushButton(text="New")
+        self.new_btn.max_width = 53
         self._nullable = nullable
-        kwargs["widgets"] = [self.choose_btn, self.layer_select]
+        kwargs["widgets"] = [self.new_btn, self.layer_select]
         kwargs["labels"] = False
         kwargs["layout"] = "horizontal"
         super().__init__(**kwargs)
         self.margins = (0, 0, 0, 0)
-        self.choose_btn.changed.disconnect()
-        self.choose_btn.changed.connect(self._spawn_new_image_widget)
+        self.new_btn.changed.disconnect()
+        self.new_btn.changed.connect(self.create_new_image)
 
     @property
     def _btn_text(self) -> str:
         return "New Image"
 
-    def _spawn_new_image_widget(self) -> None:
+    def create_new_image(self) -> None:
         """
         Creates a dialog to add an image to viewer.
 

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -1,11 +1,11 @@
-import os
 from enum import Enum
 from pathlib import Path
 from typing import Any, List, Sequence
 
-from magicgui.types import ChoicesType, FileDialogMode, PathLike
+from magicgui.types import ChoicesType, PathLike
 from magicgui.widgets import ComboBox, Container, PushButton, request_values
 from napari import current_viewer
+from napari.layers import Layer
 from napari.utils._magicgui import get_layers
 
 
@@ -55,7 +55,7 @@ class MutableOutputWidget(Container):
         for widget in self.parent._magic_widget.parent._magic_widget:
             if widget is self:
                 continue
-            if isinstance(widget, ComboBox):
+            if isinstance(widget, ComboBox) and issubclass(widget.annotation, Layer):
                 selection_name = widget.current_choice
                 if selection_name != "":
                     selection = current_viewer().layers[selection_name]

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -1,0 +1,189 @@
+from enum import Enum
+import os
+from pathlib import Path
+from typing import Any, List, Sequence
+from magicgui import magicgui
+from magicgui.types import FileDialogMode, PathLike, ChoicesType
+from magicgui.widgets import Container, ComboBox, PushButton
+from napari.utils._magicgui import get_layers, find_viewer_ancestor
+
+class MutableOutputWidget(Container):
+    """
+    A ComboBox widget combined with a button that creates new layers.
+    Made for preallocated output creation convenience.
+    """
+
+    """
+    Default constructor
+
+    :param choices: determines how the ComboBox choices are populated
+    :param nullable: iff true allows no selection as an option
+    :param kwargs: other args
+    """
+    def __init__(
+        self,
+        choices: ChoicesType = get_layers,
+        nullable=False,
+        **kwargs,
+    ):
+        value = kwargs.pop("value", None)
+        if value is None:
+            value = ""
+        
+        self.line_edit = ComboBox(choices=choices,**kwargs)
+        self.choose_btn = PushButton(text="New Image")
+        self._nullable = nullable
+        kwargs["widgets"] = [self.line_edit, self.choose_btn]
+        kwargs["labels"] = False
+        kwargs["layout"] = "horizontal"
+        super().__init__(**kwargs)
+        self.margins = (0, 0, 0, 0)
+        self.choose_btn.changed.disconnect()
+        self.choose_btn.changed.connect(self._spawn_new_image_widget)
+
+
+    @property
+    def _btn_text(self) -> str:
+        return "New Image"
+
+
+    def _spawn_new_image_widget(self) -> None:
+        """
+        Creates a dialog to add an image to viewer.
+
+
+        Parameters
+        ----------
+        viewer : napari.components.ViewerModel
+            Napari viewer containing the rendered scene, layers, and controls.
+        """
+
+        # Define an enum for array type selection
+        class BackingData(Enum):
+            NumPy = 'NumPy'
+            Zarr = 'Zarr'
+
+        # Define the magicgui widget for parameter harvesting
+        @magicgui(
+            call_button="Create",
+            name={'tooltip': "If blank, a name will be generated"},
+            dimensions={'tooltip': "The size of the new image"},
+            array_type={'tooltip': "The backing data array implementation"},
+            fill_value={'tooltip': "Starting value for all pixels"},
+        )
+        def _new_image_widget(
+            name: str = "",
+            dimensions: List[int] = [512, 512],
+            array_type: BackingData = BackingData.NumPy,
+            fill_value: float = 0.0,
+        ) -> None:
+
+            if array_type is BackingData.NumPy:
+                import numpy as np
+
+                data = np.full(tuple(dimensions), fill_value)
+
+            elif array_type is BackingData.Zarr:
+                # Zarr is not shipped by default, but we can try to support it
+                import zarr
+
+                data = zarr.full(dimensions, fill_value)
+
+            # give the data array to the viewer.
+            # Replace blank names with None so the Image class generates a name
+            find_viewer_ancestor(self.native).add_image(
+                name=name if len(name) else None,
+                data=data,
+            )
+
+        # Once called (i.e. "Create"  is clicked), the widget will be destroyed
+        # This means one click of "New image layer" will produce exactly one image,
+        # Which is consistent with the other new layer buttons.
+        _new_image_widget.called.connect(_new_image_widget.close)
+        # _new_image_widget.native.setParent(viewer.window._qt_window)
+
+        # Show the widget (as a modal dialog, outside of the napari window)
+        _new_image_widget.show()
+
+    @property
+    def value(self) -> tuple[Path, ...] | Path | None:
+        """Return current value of the widget.  This may be interpreted by backends."""
+        text = self.line_edit.value
+        if self._nullable and not text:
+            return None
+        if self.mode is FileDialogMode.EXISTING_FILES:
+            return tuple(Path(p) for p in text.split(", ") if p.strip())
+        return Path(text)
+
+    @value.setter
+    def value(self, value: Sequence[PathLike] | PathLike | None):
+        """Set current file path."""
+        if value is None and self._nullable:
+            value = ""
+        elif isinstance(value, (list, tuple)):
+            value = ", ".join(os.fspath(Path(p).expanduser().absolute()) for p in value)
+        elif isinstance(value, (str, Path)):
+            value = os.fspath(Path(value).expanduser().absolute())
+        else:
+            raise TypeError(
+                f"value must be a string, or list/tuple of strings, got {type(value)}"
+            )
+        self.line_edit.value = value
+
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return f"FileEdit(mode={self.mode.value!r}, value={self.value!r})"
+
+    # -- CategoricalWidget functions -- #
+
+    @property
+    def value(self):
+        """Return current value of the widget."""
+        return self.line_edit.value
+
+    @value.setter
+    def value(self, value):
+        self.line_edit.value = value
+
+    @property
+    def options(self) -> dict:
+        return self.line_edit.options
+
+    def reset_choices(self, *_: Any):
+        """Reset choices to the default state.
+
+        If self._default_choices is a callable, this may NOT be the exact same set of
+        choices as when the widget was instantiated, if the callable relies on external
+        state.
+        """
+        self.line_edit.reset_choices()
+
+    @property
+    def current_choice(self) -> str:
+        """Return the text of the currently selected choice."""
+        return self.line_edit.current_choice
+
+    def __len__(self) -> int:
+        """Return the number of choices."""
+        return self.line_edit.__len__()
+
+    def get_choice(self, choice_name: str):
+        """Get data for the provided ``choice_name``."""
+        return self.line_edit.get_choice(choice_name)
+
+    def set_choice(self, choice_name: str, data: Any = None):
+        """Set data for the provided ``choice_name``."""
+        return self.line_edit.set_choice(choice_name, data)
+
+    def del_choice(self, choice_name: str):
+        """Delete the provided ``choice_name`` and associated data."""
+        return self.line_edit.del_choice(choice_name)
+
+    @property
+    def choices(self):
+        """Available value choices for this widget."""
+        return self.line_edit.choices
+
+    @choices.setter
+    def choices(self, choices: ChoicesType):
+        self.line_edit.choices = choices

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -53,7 +53,8 @@ class MutableOutputWidget(Container):
     def _default_new_shape(self):
         # Attempt to guess a good size based off of the first image input
         for widget in self.parent._magic_widget.parent._magic_widget:
-            if widget is self: continue
+            if widget is self:
+                continue
             if isinstance(widget, ComboBox):
                 selection_name = widget.current_choice
                 if selection_name != "":
@@ -76,7 +77,6 @@ class MutableOutputWidget(Container):
         class BackingData(Enum):
             NumPy = "NumPy"
             Zarr = "Zarr"
-
 
         # Define the magicgui widget for parameter harvesting
         params = request_values(
@@ -124,26 +124,10 @@ class MutableOutputWidget(Container):
     @property
     def value(self) -> tuple[Path, ...] | Path | None:
         """Return current value of the widget.  This may be interpreted by backends."""
-        text = self.layer_select.value
-        if self._nullable and not text:
-            return None
-        if self.mode is FileDialogMode.EXISTING_FILES:
-            return tuple(Path(p) for p in text.split(", ") if p.strip())
-        return Path(text)
+        return self.layer_select.value
 
     @value.setter
     def value(self, value: Sequence[PathLike] | PathLike | None):
-        """Set current file path."""
-        if value is None and self._nullable:
-            value = ""
-        elif isinstance(value, (list, tuple)):
-            value = ", ".join(os.fspath(Path(p).expanduser().absolute()) for p in value)
-        elif isinstance(value, (str, Path)):
-            value = os.fspath(Path(value).expanduser().absolute())
-        else:
-            raise TypeError(
-                f"value must be a string, or list/tuple of strings, got {type(value)}"
-            )
         self.layer_select.value = value
 
     # -- CategoricalWidget functions -- #

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -1,8 +1,7 @@
 from enum import Enum
-from pathlib import Path
-from typing import Any, List, Sequence
+from typing import Any, List
 
-from magicgui.types import ChoicesType, PathLike
+from magicgui.types import ChoicesType
 from magicgui.widgets import ComboBox, Container, PushButton, request_values
 from napari import current_viewer
 from napari.layers import Layer
@@ -122,12 +121,12 @@ class MutableOutputWidget(Container):
             )
 
     @property
-    def value(self) -> tuple[Path, ...] | Path | None:
+    def value(self) -> Any:
         """Return current value of the widget.  This may be interpreted by backends."""
         return self.layer_select.value
 
     @value.setter
-    def value(self, value: Sequence[PathLike] | PathLike | None):
+    def value(self, value: Any):
         self.layer_select.value = value
 
     # -- CategoricalWidget functions -- #

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -35,6 +35,7 @@ class MutableOutputWidget(Container):
 
         self.layer_select = ComboBox(choices=choices, **kwargs)
         self.choose_btn = PushButton(text="New")
+        self.choose_btn.max_width = 53
         self._nullable = nullable
         kwargs["widgets"] = [self.choose_btn, self.layer_select]
         kwargs["labels"] = False

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -33,10 +33,10 @@ class MutableOutputWidget(Container):
         if value is None:
             value = ""
 
-        self.line_edit = ComboBox(choices=choices, **kwargs)
-        self.choose_btn = PushButton(text="New Image")
+        self.layer_select = ComboBox(choices=choices, **kwargs)
+        self.choose_btn = PushButton(text="New")
         self._nullable = nullable
-        kwargs["widgets"] = [self.line_edit, self.choose_btn]
+        kwargs["widgets"] = [self.choose_btn, self.layer_select]
         kwargs["labels"] = False
         kwargs["layout"] = "horizontal"
         super().__init__(**kwargs)
@@ -110,7 +110,7 @@ class MutableOutputWidget(Container):
     @property
     def value(self) -> tuple[Path, ...] | Path | None:
         """Return current value of the widget.  This may be interpreted by backends."""
-        text = self.line_edit.value
+        text = self.layer_select.value
         if self._nullable and not text:
             return None
         if self.mode is FileDialogMode.EXISTING_FILES:
@@ -130,26 +130,22 @@ class MutableOutputWidget(Container):
             raise TypeError(
                 f"value must be a string, or list/tuple of strings, got {type(value)}"
             )
-        self.line_edit.value = value
-
-    def __repr__(self) -> str:
-        """Return string representation."""
-        return f"FileEdit(mode={self.mode.value!r}, value={self.value!r})"
+        self.layer_select.value = value
 
     # -- CategoricalWidget functions -- #
 
     @property
     def value(self):
         """Return current value of the widget."""
-        return self.line_edit.value
+        return self.layer_select.value
 
     @value.setter
     def value(self, value):
-        self.line_edit.value = value
+        self.layer_select.value = value
 
     @property
     def options(self) -> dict:
-        return self.line_edit.options
+        return self.layer_select.options
 
     def reset_choices(self, *_: Any):
         """Reset choices to the default state.
@@ -158,34 +154,34 @@ class MutableOutputWidget(Container):
         choices as when the widget was instantiated, if the callable relies on external
         state.
         """
-        self.line_edit.reset_choices()
+        self.layer_select.reset_choices()
 
     @property
     def current_choice(self) -> str:
         """Return the text of the currently selected choice."""
-        return self.line_edit.current_choice
+        return self.layer_select.current_choice
 
     def __len__(self) -> int:
         """Return the number of choices."""
-        return self.line_edit.__len__()
+        return self.layer_select.__len__()
 
     def get_choice(self, choice_name: str):
         """Get data for the provided ``choice_name``."""
-        return self.line_edit.get_choice(choice_name)
+        return self.layer_select.get_choice(choice_name)
 
     def set_choice(self, choice_name: str, data: Any = None):
         """Set data for the provided ``choice_name``."""
-        return self.line_edit.set_choice(choice_name, data)
+        return self.layer_select.set_choice(choice_name, data)
 
     def del_choice(self, choice_name: str):
         """Delete the provided ``choice_name`` and associated data."""
-        return self.line_edit.del_choice(choice_name)
+        return self.layer_select.del_choice(choice_name)
 
     @property
     def choices(self):
         """Available value choices for this widget."""
-        return self.line_edit.choices
+        return self.layer_select.choices
 
     @choices.setter
     def choices(self, choices: ChoicesType):
-        self.line_edit.choices = choices
+        self.layer_select.choices = choices

--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -613,9 +613,8 @@ def _widget_for_item_and_type(
     :param type_hint: The PYTHON type for the parameter
     :return: The best widget type, if it is known
     """
-    if type_hint == "napari.layers.Image":
-        if item.isInput() and item.isOutput():
-            return "napari_imagej._helper_widgets.MutableOutputWidget"
+    if type_hint == "napari.layers.Image" and item.isInput() and item.isOutput():
+        return "napari_imagej._helper_widgets.MutableOutputWidget"
 
     style: str = item.getWidgetStyle()
     if style not in _supported_styles:

--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -603,15 +603,21 @@ def _add_param_metadata(metadata: dict, key: str, value: Any) -> None:
         pass
 
 
-def _widget_for_style_and_type(
-    style: str, type_hint: Union[type, str]
+def _widget_for_item_and_type(
+    item: "jc.ModuleItem",
+    type_hint: Union[type, str],
 ) -> Optional[str]:
     """
     Convenience function for interacting with _supported_styles
-    :param style: The SciJava style
+    :param item: The ModuleItem with a style
     :param type_hint: The PYTHON type for the parameter
     :return: The best widget type, if it is known
     """
+    if type_hint == "napari.layers.Image":
+        if item.isInput() and item.isOutput():
+            return "napari_imagej._helper_widgets.MutableOutputWidget"
+
+    style: str = item.getWidgetStyle()
     if style not in _supported_styles:
         return None
     style_options = _supported_styles[style]
@@ -642,9 +648,7 @@ def _add_scijava_metadata(
         if choices is not None and len(choices) > 0:
             _add_param_metadata(param_map, "choices", choices)
         # Convert supported SciJava styles to widget types.
-        widget_type = _widget_for_style_and_type(
-            input.getWidgetStyle(), type_hints[input.getName()]
-        )
+        widget_type = _widget_for_item_and_type(input, type_hints[input.getName()])
         if widget_type is not None:
             _add_param_metadata(param_map, "widget_type", widget_type)
 

--- a/tests/test_helper_widgets.py
+++ b/tests/test_helper_widgets.py
@@ -1,4 +1,6 @@
+import napari
 from magicgui.widgets import ComboBox, Container, PushButton
+from napari import current_viewer
 
 from napari_imagej._helper_widgets import MutableOutputWidget
 
@@ -13,3 +15,39 @@ def test_mutable_output_widget_chosen():
     assert isinstance(children[1], PushButton)
     assert children[1].max_width == 53
     assert widget.current_choice == ""
+    assert widget.layout == "horizontal"
+    assert widget.margins == (0, 0, 0, 0)
+
+
+def test_mutable_output_default_shape(make_napari_viewer):
+    """Tests that MutableOutputWidget's default size changes based on"""
+    make_napari_viewer()
+
+    def func(output: "napari.layers.Image", input: "napari.layers.Image"):
+        print(output.name, input.name)
+
+    import magicgui
+
+    widget = magicgui.magicgui(
+        function=func,
+        call_button=False,
+        output={"widget_type": "napari_imagej._helper_widgets.MutableOutputWidget"},
+    )
+    current_viewer().window.add_dock_widget(widget)
+
+    output_widget = widget._list[0]
+    input_widget = widget._list[1]
+    assert isinstance(output_widget, MutableOutputWidget)
+    assert isinstance(input_widget, ComboBox)
+
+    # Assert when no selection, output shape is default
+    assert input_widget.current_choice == ""
+    assert output_widget._default_new_shape() == [512, 512]
+
+    # Add new image
+    shape = (128, 128, 3)
+    import numpy as np
+
+    current_viewer().add_image(data=np.ones(shape), name="img")
+    assert input_widget.current_choice == "img"
+    assert output_widget._default_new_shape() == shape

--- a/tests/test_helper_widgets.py
+++ b/tests/test_helper_widgets.py
@@ -1,0 +1,15 @@
+from magicgui.widgets import ComboBox, Container, PushButton
+
+from napari_imagej._helper_widgets import MutableOutputWidget
+
+
+def test_mutable_output_widget_chosen():
+
+    widget = MutableOutputWidget()
+    assert isinstance(widget, Container)
+    children = [w for w in widget]
+    assert len(children) == 2
+    assert isinstance(children[0], ComboBox)
+    assert isinstance(children[1], PushButton)
+    assert children[1].max_width == 53
+    assert widget.current_choice == ""

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -530,7 +530,10 @@ def test_widget_for_style_and_type(style, type_hint, widget_type, widget_class):
     :param widget_type: the name of a magicgui widget
     :param widget_class: the class corresponding to name
     """
-    actual = _module_utils._widget_for_style_and_type(style, type_hint)
+    # We only need item for the getWidgetStyle() function
+    item: DummyModuleItem = DummyModuleItem()
+    item.setWidgetStyle(style)
+    actual = _module_utils._widget_for_item_and_type(item, type_hint)
     assert widget_type == actual
 
     def func(foo):

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -549,6 +549,30 @@ def test_widget_for_style_and_type(style, type_hint, widget_type, widget_class):
     assert isinstance(widget._list[0], widget_class)
 
 
+def test_helper_widgets_for_item_and_type():
+    from napari_imagej._helper_widgets import MutableOutputWidget
+
+    # MutableOutputWidget
+    item: DummyModuleItem = DummyModuleItem(
+        jtype=jc.ArrayImg, isInput=True, isOutput=True
+    )
+    type_hint = "napari.layers.Image"
+    actual = _module_utils._widget_for_item_and_type(item, type_hint)
+    assert "napari_imagej._helper_widgets.MutableOutputWidget" == actual
+
+    def func(foo):
+        print(foo, "bar")
+
+    func.__annotation__ = {"foo": type_hint}
+    import magicgui
+
+    widget = magicgui.magicgui(
+        function=func, call_button=False, foo={"widget_type": actual}
+    )
+    assert len(widget._list) == 1
+    assert isinstance(widget._list[0], MutableOutputWidget)
+
+
 def test_all_styles_in_parameterizations():
     """
     Tests that all style mappings declared in _supported_styles


### PR DESCRIPTION
This PR creates a new magicgui Widget type, `MutableOutputWidget`, which presents a "New Image" button next to the normal layer selection box. This makes preallocated outputs much easier to create!

By and large, this work was copied over from https://github.com/napari/napari/pull/4605, but I had to create a new widget, and introduce some sneaky behavior to add the image to the viewer.

TODO:
* [x] Add functionality to make a layer of the same size as another
* [x] Determine why the button is to the left of the ComboBox.
* [x] Test the widget