### PR TITLE
Ensure Optional Mutable Layer Outputs are returned, not updated

### DIFF
--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -254,18 +254,8 @@ def _mutable_layers(
     """
     mutable_layers: List[Layer] = []
     for item, input in zip(unresolved_inputs, user_resolved_inputs):
-        # We don't care about input unless it is a layer
-        if not isinstance(input, Layer):
-            continue
-        # We don't care about input unless it is an output
-        if not item.isOutput():
-            continue
-        # We don't care about input unless it was required
-        # as optional mutable outputs are resolved by the module
-        if not item.isRequired():
-            continue
-
-        mutable_layers.append(input)
+        if isinstance(input, Layer) and item.isOutput():
+            mutable_layers.append(input)
 
     return mutable_layers
 

--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -468,6 +468,7 @@ def _layerDataTuple_from_layer(layer: Layer):
 
 def _pure_module_outputs(
     module: "jc.Module",
+    user_inputs: List["jc.ModuleItem"],
 ) -> Tuple[Optional[List[LayerDataTuple]], List[Tuple[str, Any]]]:
     """Gets the pure outputs of the module, or None if the module has no pure output."""
     # Outputs delivered to users through the return of the magicgui widget.
@@ -481,10 +482,7 @@ def _pure_module_outputs(
     for output_entry in outputs.entrySet():
         # Ignore outputs that are also required inputs
         output_name = ij().py.from_java(output_entry.getKey())
-        if (
-            output_name in module.getInputs()
-            and module.getInfo().getInput(output_name).isRequired()
-        ):
+        if module.getInfo().getInput(output_name) in user_inputs:
             continue
         output = ij().py.from_java(output_entry.getValue())
         # Add LayerDataTuples directly
@@ -711,7 +709,7 @@ def functionify_module_execution(
         # get all outputs
         layer_outputs: List[LayerDataTuple]
         widget_outputs: List[Any]
-        layer_outputs, widget_outputs = _pure_module_outputs(module)
+        layer_outputs, widget_outputs = _pure_module_outputs(module, unresolved_inputs)
         # log outputs
         if layer_outputs is not None:
             for output in layer_outputs:

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -691,7 +691,9 @@ def run_module_from_script(ij, tmp_path, script):
     )
     _module_utils._run_module(module)
     _module_utils._postprocess_module(module)
-    return _module_utils._pure_module_outputs(module)
+    unresolved_inputs = _module_utils._filter_unresolved_inputs(module, info.inputs())
+    unresolved_inputs = _module_utils._sink_optional_inputs(unresolved_inputs)
+    return _module_utils._pure_module_outputs(module, unresolved_inputs)
 
 
 script_zero_layer_zero_widget: str = """
@@ -805,7 +807,9 @@ widget_parameterizations = [
     (script_zero_layer_two_widget, 0, 2),
     (script_one_layer_two_widget, 1, 2),
     (script_two_layer_two_widget, 2, 2),
+    # No layers returned, the required BOTH is just updated
     (script_both_but_required, 0, 0),
+    # One layer returned as we create the optional input internally
     (script_both_but_optional, 1, 0),
 ]
 

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -804,10 +804,30 @@ def test_module_outputs_number(ij, tmp_path, script, num_layer, num_widget):
     assert num_widget == len(widget_outputs)
 
 
+script_both_but_optional: str = """
+#@BOTH Img(required=false) d
+
+from net.imglib2.img.array import ArrayImgs
+
+if d is None:
+    d = ArrayImgs.unsignedBytes(10, 10)
+
+d[:, :] = 1
+"""
+
+script_both_but_required: str = """
+#@BOTH Img(required=true) d
+
+from net.imglib2.img.array import ArrayImgs
+
+d[:, :] = 1
+"""
 out_type_params = [
     (script_zero_layer_one_widget, None),
     (script_one_layer_one_widget, List[LayerDataTuple]),
     (script_two_layer_one_widget, List[LayerDataTuple]),
+    (script_both_but_optional, List[LayerDataTuple]),
+    (script_both_but_required, None),
 ]
 
 
@@ -844,8 +864,16 @@ def test_mutable_layers():
         DummyModuleItem(name="b", isOutput=True),
         DummyModuleItem(name="c", isOutput=False),
         DummyModuleItem(name="d", isOutput=True),
+        DummyModuleItem(name="a", isOutput=False, isRequired=False),
+        DummyModuleItem(name="b", isOutput=True, isRequired=False),
+        DummyModuleItem(name="c", isOutput=False, isRequired=False),
+        DummyModuleItem(name="d", isOutput=True, isRequired=False),
     ]
     user_resolved_inputs = [
+        1,
+        2,
+        Image(data=numpy.ones((4, 4))),
+        Image(data=numpy.ones((4, 4))),
         1,
         2,
         Image(data=numpy.ones((4, 4))),

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -870,10 +870,10 @@ def test_mutable_layers():
         DummyModuleItem(name="b", isOutput=True),
         DummyModuleItem(name="c", isOutput=False),
         DummyModuleItem(name="d", isOutput=True),
-        DummyModuleItem(name="a", isOutput=False, isRequired=False),
-        DummyModuleItem(name="b", isOutput=True, isRequired=False),
-        DummyModuleItem(name="c", isOutput=False, isRequired=False),
-        DummyModuleItem(name="d", isOutput=True, isRequired=False),
+        DummyModuleItem(name="e", isOutput=False, isRequired=False),
+        DummyModuleItem(name="f", isOutput=True, isRequired=False),
+        DummyModuleItem(name="g", isOutput=False, isRequired=False),
+        DummyModuleItem(name="h", isOutput=True, isRequired=False),
     ]
     user_resolved_inputs = [
         1,
@@ -888,5 +888,6 @@ def test_mutable_layers():
     mutable_layers = _module_utils._mutable_layers(
         unresolved_inputs, user_resolved_inputs
     )
-    assert 1 == len(mutable_layers)
+    assert 2 == len(mutable_layers)
     assert user_resolved_inputs[3] in mutable_layers
+    assert user_resolved_inputs[7] in mutable_layers


### PR DESCRIPTION
We treat Layer output parameters differently. Preallocated output layers should just be updated, not returned, whereas all others are returned. We were not previously checking to make sure that they were required, as well; this meant that **optional** mutable outputs were not returned by the Op.

Because we *always* delegate optional mutable output resolution to the Op, to simplify things, this resulted in those outputs being ignored. This PR fixes that, ignoring (but updating) only *required* mutable outputs.