### PR TITLE
66 persistent vs modal initialization widgets

### DIFF
--- a/src/napari_imagej/_flow_layout.py
+++ b/src/napari_imagej/_flow_layout.py
@@ -1,0 +1,97 @@
+from qtpy.QtCore import QMargins, QPoint, QRect, QSize, Qt
+from qtpy.QtWidgets import QLayout, QSizePolicy
+
+# Copied from Qt for Python's Example:
+# https://doc.qt.io/qtforpython/examples/example_widgets_layouts_flowlayout.html
+
+
+class FlowLayout(QLayout):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        if parent is not None:
+            self.setContentsMargins(QMargins(0, 0, 0, 0))
+
+        self._item_list = []
+
+    def __del__(self):
+        item = self.takeAt(0)
+        while item:
+            item = self.takeAt(0)
+
+    def addItem(self, item):
+        self._item_list.append(item)
+
+    def count(self):
+        return len(self._item_list)
+
+    def itemAt(self, index):
+        if 0 <= index < len(self._item_list):
+            return self._item_list[index]
+
+        return None
+
+    def takeAt(self, index):
+        if 0 <= index < len(self._item_list):
+            return self._item_list.pop(index)
+
+        return None
+
+    def expandingDirections(self):
+        return Qt.Orientation(0)
+
+    def hasHeightForWidth(self):
+        return True
+
+    def heightForWidth(self, width):
+        height = self._do_layout(QRect(0, 0, width, 0), True)
+        return height
+
+    def setGeometry(self, rect):
+        super(FlowLayout, self).setGeometry(rect)
+        self._do_layout(rect, False)
+
+    def sizeHint(self):
+        return self.minimumSize()
+
+    def minimumSize(self):
+        size = QSize()
+
+        for item in self._item_list:
+            size = size.expandedTo(item.minimumSize())
+
+        size += QSize(
+            2 * self.contentsMargins().top(), 2 * self.contentsMargins().top()
+        )
+        return size
+
+    def _do_layout(self, rect, test_only):
+        x = rect.x()
+        y = rect.y()
+        line_height = 0
+        spacing = self.spacing()
+
+        for item in self._item_list:
+            style = item.widget().style()
+            layout_spacing_x = style.layoutSpacing(
+                QSizePolicy.PushButton, QSizePolicy.PushButton, Qt.Horizontal
+            )
+            layout_spacing_y = style.layoutSpacing(
+                QSizePolicy.PushButton, QSizePolicy.PushButton, Qt.Vertical
+            )
+            space_x = spacing + layout_spacing_x
+            space_y = spacing + layout_spacing_y
+            next_x = x + item.sizeHint().width() + space_x
+            if next_x - space_x > rect.right() and line_height > 0:
+                x = rect.x()
+                y = y + line_height + space_y
+                next_x = x + item.sizeHint().width() + space_x
+                line_height = 0
+
+            if not test_only:
+                item.setGeometry(QRect(QPoint(x, y), item.sizeHint()))
+
+            x = next_x
+            line_height = max(line_height, item.sizeHint().height())
+
+        return y + line_height - rect.y()

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -134,10 +134,21 @@ class MutableOutputWidget(Container):
 
         # give the data array to the viewer.
         # Replace blank names with None so the Image class generates a name
-        current_viewer().add_image(
+        layer = current_viewer().add_image(
             name=params["name"] if len(params["name"]) else None,
             data=data,
         )
+
+        # Find the "oldest" magicgui ancestor, and reset choices.
+        # This allows the new layer to propagate to children.
+        mgui = self
+        while hasattr(mgui.parent, "_magic_widget"):
+            mgui = mgui.parent._magic_widget
+        mgui.reset_choices()
+        # Specifically for this widget, set this selection
+        # to the newly created layer.
+        # This is almost definitely what the user wants!
+        self.value = layer
 
     @property
     def value(self) -> Any:

--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -785,6 +785,15 @@ def _request_values_args(
     return args
 
 
+def _execute_function_with_params(viewer: Viewer, params: Dict, func: Callable):
+    if params is not None:
+        inputs = params.values()
+        outputs: Optional[List[LayerDataTuple]] = func(*inputs)
+        if outputs is not None:
+            for output in outputs:
+                viewer.add_layer(Layer.create(*output))
+
+
 def execute_function_modally(
     viewer: Viewer, name: str, func: Callable, param_options: Dict[str, Dict]
 ) -> None:
@@ -792,9 +801,4 @@ def execute_function_modally(
     args: dict = _request_values_args(func, param_options)
     # Request values
     params = request_values(title=name, **args)
-    if params is not None:
-        inputs = params.values()
-        outputs: Optional[List[LayerDataTuple]] = func(*inputs)
-        if outputs is not None:
-            for output in outputs:
-                viewer.add_layer(Layer.create(*output))
+    _execute_function_with_params(viewer, params, func)

--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -2,10 +2,12 @@ from functools import lru_cache
 from inspect import Parameter, Signature, signature
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
-from magicgui.widgets import Container, Label, LineEdit, Widget
-from napari import Viewer
+from magicgui.widgets import Container, Label, LineEdit, Widget, request_values
+from magicgui.widgets._bases import CategoricalWidget
+from napari import Viewer, current_viewer
 from napari.layers import Layer
 from napari.types import LayerDataTuple
+from napari.utils._magicgui import find_viewer_ancestor
 from scyjava import JavaIterable, JavaMap, JavaSet, Priority
 
 from napari_imagej._ptypes import TypeMappings, _supported_styles
@@ -738,3 +740,61 @@ def functionify_module_execution(
     )
 
     return (module_execute, magic_kwargs)
+
+
+def _get_layers_hack(gui: CategoricalWidget) -> List[Layer]:
+    """Mimics the functional changes of https://github.com/napari/napari/pull/4715"""
+    viewer = find_viewer_ancestor(gui.native)
+    if viewer is None:
+        viewer = current_viewer()
+    return [x for x in viewer.layers if isinstance(x, gui.annotation)]
+
+
+def _request_values_args(
+    func: Callable, param_options: Dict[str, Dict]
+) -> Dict[str, Dict]:
+    """Gets the arguments for request_values from a function"""
+    import inspect
+
+    signature = inspect.signature(func)
+
+    # Convert function parameters and param_options to a dictionary
+    args = {}
+    for param in signature.parameters.values():
+        args[param.name] = {}
+        # Add type to dict
+        args[param.name]["annotation"] = param.annotation
+        # Add magicgui preferences, if they exist, to dict
+        if param.name in param_options:
+            args[param.name]["options"] = param_options[param.name]
+        # Add default value, if we have one, to dict
+        if param.default is not inspect._empty:
+            args[param.name]["value"] = param.default
+        # Add layer choices, if relevant
+        if (
+            inspect.isclass(param.annotation) and issubclass(param.annotation, Layer)
+        ) or (
+            type(param.annotation) is str
+            and param.annotation.startswith("napari.layers")
+        ):
+            if "options" not in args[param.name]:
+                args[param.name]["options"] = {}
+            # TODO: Once napari > 0.4.16 is released, replace this with
+            # napari.util._magicgui.get_layers
+            args[param.name]["options"]["choices"] = _get_layers_hack
+    return args
+
+
+def execute_function_modally(
+    viewer: Viewer, name: str, func: Callable, param_options: Dict[str, Dict]
+) -> None:
+
+    args: dict = _request_values_args(func, param_options)
+    # Request values
+    params = request_values(title=name, **args)
+    if params is not None:
+        inputs = params.values()
+        outputs: Optional[List[LayerDataTuple]] = func(*inputs)
+        if outputs is not None:
+            for output in outputs:
+                viewer.add_layer(Layer.create(*output))

--- a/tests/test_helper_widgets.py
+++ b/tests/test_helper_widgets.py
@@ -95,7 +95,9 @@ if importlib.util.find_spec("xarray"):
 
 
 @pytest.mark.parametrize(argnames=["choice", "type"], argvalues=backing_types)
-def test_mutable_output_add_new_image(output_widget: MutableOutputWidget, choice, type):
+def test_mutable_output_add_new_image(
+    input_widget: ComboBox, output_widget: MutableOutputWidget, choice, type
+):
     """Tests that MutableOutputWidget can add a new image from params"""
 
     params = {
@@ -113,3 +115,7 @@ def test_mutable_output_add_new_image(output_widget: MutableOutputWidget, choice
     assert isinstance(foo.data, type)
     assert (100, 100, 3) == foo.data.shape
     assert (3) == np.unique(foo.data)
+
+    assert foo in input_widget.choices
+    assert foo in output_widget.choices
+    assert foo is output_widget.value

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -15,6 +15,7 @@ from magicgui.widgets import (
     SpinBox,
     Widget,
 )
+from napari import Viewer
 from napari.layers import Image, Labels, Layer, Points, Shapes
 from napari.types import LayerDataTuple
 
@@ -947,3 +948,25 @@ def test_request_values_args():
     assert args["f"]["annotation"] == str
     assert "options" not in args["f"]
     assert args["f"]["value"] == "also default"
+
+
+def test_execute_function_with_params(make_napari_viewer, ij):
+    viewer: Viewer = make_napari_viewer()
+    info = ij.module().getModuleById(
+        "command:net.imagej.ops.commands.filter.FrangiVesselness"
+    )
+    func, _ = _module_utils.functionify_module_execution(
+        viewer, info.createModule(), info
+    )
+    params: Dict[str, Any] = dict(
+        input=numpy.ones((100, 100)),
+        doGauss=False,
+        spacingString="1, 1",
+        scaleString="2, 5",
+    )
+    # Ensure that a None params does nothing
+    _module_utils._execute_function_with_params(viewer, None, func)
+    assert len(viewer.layers) == 0
+
+    _module_utils._execute_function_with_params(viewer, params, func)
+    assert len(viewer.layers) == 1

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -895,3 +895,55 @@ def test_mutable_layers():
     assert 2 == len(mutable_layers)
     assert user_resolved_inputs[3] in mutable_layers
     assert user_resolved_inputs[7] in mutable_layers
+
+
+def test_request_values_args():
+    import napari
+
+    def foo(
+        a,
+        b: str,
+        c: Image,
+        d: "napari.layers.Image",
+        e="default",
+        f: str = "also default",
+    ):
+        return "I didn't use any of my parameters"
+
+    param_options = {}
+    param_options["a"] = {}
+    param_options["a"]["tooltip"] = "We don't use this"
+
+    args: dict = _module_utils._request_values_args(foo, param_options)
+
+    import inspect
+
+    assert "a" in args
+    assert args["a"]["annotation"] == inspect._empty
+    assert args["a"]["options"] == dict(tooltip="We don't use this")
+    assert "value" not in args["a"]
+
+    assert "b" in args
+    assert args["b"]["annotation"] == str
+    assert "options" not in args["b"]
+    assert "value" not in args["b"]
+
+    assert "c" in args
+    assert args["c"]["annotation"] == Image
+    assert args["c"]["options"] == dict(choices=_module_utils._get_layers_hack)
+    assert "value" not in args["c"]
+
+    assert "d" in args
+    assert args["d"]["annotation"] == "napari.layers.Image"
+    assert args["d"]["options"] == dict(choices=_module_utils._get_layers_hack)
+    assert "value" not in args["d"]
+
+    assert "e" in args
+    assert args["e"]["annotation"] == inspect._empty
+    assert "options" not in args["e"]
+    assert args["e"]["value"] == "default"
+
+    assert "f" in args
+    assert args["f"]["annotation"] == str
+    assert "options" not in args["f"]
+    assert args["f"]["value"] == "also default"


### PR DESCRIPTION
This PR adds a modal option for running our ImageJ functionality.

![ModalOnTopOfModalWorking](https://user-images.githubusercontent.com/29754838/175068994-e9499af3-ae20-4183-b160-55930e4df52b.gif)

TODO:
* [x] Add a name to the modal widgets. Right now there is nothing linking them to the Module/Op that spawned it, other than parameter names. Of course, you can only spawn one at a time, so that should help ease confusion, but still...
* [x] Rename buttons, and add tooltips to the buttons to explain the differences (i.e. when you might use one vs. the other).
* [ ] Test as much as possible.
* [x] ~~Merge https://github.com/napari/napari/pull/4715 and depend on the next release in `setup.cfg` and in `<dev->environment.yml`~~ Unnecessary due to a hack