### PR TITLE
Improve keyboard behavior

### DIFF
--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -802,3 +802,11 @@ def execute_function_modally(
     # Request values
     params = request_values(title=name, **args)
     _execute_function_with_params(viewer, params, func)
+
+
+def convert_searchResult_to_info(search_result: "jc.SearchResult") -> "jc.ModuleInfo":
+    info = search_result.info()
+    # There is an extra step for Ops - we actually need the CommandInfo
+    if isinstance(info, jc.OpInfo):
+        info = info.cInfo()
+    return info

--- a/src/napari_imagej/widget.py
+++ b/src/napari_imagej/widget.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 from threading import Thread
 from typing import Callable, Dict, List, Tuple
 
+from magicgui import magicgui
 from napari import Viewer
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
@@ -377,9 +378,9 @@ class FocusWidget(QWidget):
                 viewer=self.viewer, name=name, func=func, param_options=param_options
             )
         else:
-            self.viewer.window.add_function_widget(
-                func, name=name, magic_kwargs=param_options
-            )
+            widget = magicgui(function=func, **param_options)
+            self.viewer.window.add_dock_widget(widget)
+            widget[0].native.setFocus()
 
     def _convert_searchResult_to_info(self, search_result):
         info = search_result.info()

--- a/src/napari_imagej/widget.py
+++ b/src/napari_imagej/widget.py
@@ -41,9 +41,11 @@ class ImageJWidget(QWidget):
         # Search Bar
         self.search: SearchbarWidget = SearchbarWidget()
         self.layout().addWidget(self.search)
-        # Bind L key to search bar. 
+        # Bind L key to search bar.
         # Note the requirement for an input parameter
-        napari_viewer.bind_key("l", lambda _: self.search.bar.setFocus(), overwrite=True)
+        napari_viewer.bind_key(
+            "l", lambda _: self.search.bar.setFocus(), overwrite=True
+        )
 
         self.results: ResultsWidget = ResultsWidget()
         self.layout().addWidget(self.results)

--- a/src/napari_imagej/widget.py
+++ b/src/napari_imagej/widget.py
@@ -41,6 +41,9 @@ class ImageJWidget(QWidget):
         # Search Bar
         self.search: SearchbarWidget = SearchbarWidget()
         self.layout().addWidget(self.search)
+        # Bind L key to search bar. 
+        # Note the requirement for an input parameter
+        napari_viewer.bind_key("l", lambda _: self.search.bar.setFocus(), overwrite=True)
 
         self.results: ResultsWidget = ResultsWidget()
         self.layout().addWidget(self.results)

--- a/src/napari_imagej/widget.py
+++ b/src/napari_imagej/widget.py
@@ -83,7 +83,7 @@ class ImageJWidget(QWidget):
         # Bind L key to search bar.
         # Note the requirement for an input parameter
         napari_viewer.bind_key(
-            "l", lambda _: self.search.bar.setFocus(), overwrite=True
+            "Control-L", lambda _: self.search.bar.setFocus(), overwrite=True
         )
 
     def _change_focused_table_entry(self, down: bool = True) -> Tuple[int, int]:

--- a/tests/test_ImageJWidget.py
+++ b/tests/test_ImageJWidget.py
@@ -1,5 +1,6 @@
 import pytest
 from napari import Viewer
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QAbstractItemView,
     QHBoxLayout,
@@ -129,7 +130,7 @@ def test_button_param_regression(ij, imagej_widget: ImageJWidget):
     assert button_params[4][0] not in imagej_widget.highlighter.tooltips
 
 
-def test_keymaps(make_napari_viewer):
+def test_keymaps(make_napari_viewer, qtbot):
     """Tests that 'L' is added to the keymap by ImageJWidget"""
     viewer: Viewer = make_napari_viewer()
     assert "L" not in viewer.keymap
@@ -138,3 +139,43 @@ def test_keymaps(make_napari_viewer):
     # TODO: I can't seem to figure out how to assert that pressing 'L'
     # sets the focus of the search bar.
     # Typing viewer.keymap['L'](viewer) does nothing. :(
+
+
+def test_result_single_click(make_napari_viewer, qtbot):
+    viewer: Viewer = make_napari_viewer()
+    imagej_widget: ImageJWidget = ImageJWidget(viewer)
+    viewer
+    # Test single click spawns buttons
+    assert len(imagej_widget.highlighter.focused_action_buttons) == 0
+    imagej_widget.results._search("Frangi")
+    item = imagej_widget.results._tables[0].item(0, 0)
+    assert item is not None
+    rect = imagej_widget.results._tables[0].visualItemRect(item)
+    qtbot.mouseClick(
+        imagej_widget.results._tables[0].viewport(), Qt.LeftButton, pos=rect.center()
+    )
+    assert len(imagej_widget.highlighter.focused_action_buttons) == 5
+
+    # Test double click spawns the widget
+
+
+def test_result_double_click(make_napari_viewer, qtbot):
+    viewer: Viewer = make_napari_viewer()
+    imagej_widget: ImageJWidget = ImageJWidget(viewer)
+    viewer
+    # Test double click spawns the widget
+    assert len(viewer.window._dock_widgets) == 0
+    imagej_widget.results._search("Frangi")
+    item = imagej_widget.results._tables[0].item(0, 0)
+    assert item is not None
+    rect = imagej_widget.results._tables[0].visualItemRect(item)
+    # HACK: For some reason, we need to click before a double click.
+    # This seems to be the issue described in
+    # https://stackoverflow.com/questions/46795224/qlistwidget-doesnt-recognize-signals-from-qtestmousedclick
+    qtbot.mouseClick(
+        imagej_widget.results._tables[0].viewport(), Qt.LeftButton, pos=rect.center()
+    )
+    qtbot.mouseDClick(
+        imagej_widget.results._tables[0].viewport(), Qt.LeftButton, pos=rect.center()
+    )
+    assert len(viewer.window._dock_widgets) == 1

--- a/tests/test_ImageJWidget.py
+++ b/tests/test_ImageJWidget.py
@@ -105,29 +105,29 @@ def test_button_param_regression(ij, imagej_widget: ImageJWidget):
     assert len(results) == 1
     searchService = ij.get("org.scijava.search.SearchService")
     imagej_widget.highlighter.focused_actions = searchService.actions(results[0])
-    button_params = imagej_widget.highlighter._button_params_from_actions()
-    assert button_params[0][0] == "Run"
+    py_actions = imagej_widget.highlighter._actions_from_result(results[0])
+    assert py_actions[0].name == "Run"
     assert (
-        imagej_widget.highlighter.tooltips[button_params[0][0]]
+        imagej_widget.highlighter.tooltips[py_actions[0][0]]
         == "Runs functionality from a modal widget. Best for single executions"
     )
-    assert button_params[1][0] == "Widget"
+    assert py_actions[1].name == "Widget"
     assert (
-        imagej_widget.highlighter.tooltips[button_params[1][0]]
+        imagej_widget.highlighter.tooltips[py_actions[1][0]]
         == "Runs functionality from a napari widget. Useful for parameter sweeping"
     )
-    assert button_params[2][0] == "Help"
+    assert py_actions[2].name == "Help"
     assert (
-        imagej_widget.highlighter.tooltips[button_params[2][0]]
+        imagej_widget.highlighter.tooltips[py_actions[2][0]]
         == "Opens the functionality's ImageJ.net wiki page"
     )
-    assert button_params[3][0] == "Source"
+    assert py_actions[3].name == "Source"
     assert (
-        imagej_widget.highlighter.tooltips[button_params[3][0]]
+        imagej_widget.highlighter.tooltips[py_actions[3][0]]
         == "Opens the source code on GitHub"
     )
-    assert button_params[4][0] == "Batch"
-    assert button_params[4][0] not in imagej_widget.highlighter.tooltips
+    assert py_actions[4].name == "Batch"
+    assert py_actions[4].name not in imagej_widget.highlighter.tooltips
 
 
 def test_keymaps(make_napari_viewer, qtbot):

--- a/tests/test_ImageJWidget.py
+++ b/tests/test_ImageJWidget.py
@@ -131,11 +131,11 @@ def test_button_param_regression(ij, imagej_widget: ImageJWidget):
 
 
 def test_keymaps(make_napari_viewer, qtbot):
-    """Tests that 'L' is added to the keymap by ImageJWidget"""
+    """Tests that 'Ctrl+L' is added to the keymap by ImageJWidget"""
     viewer: Viewer = make_napari_viewer()
-    assert "L" not in viewer.keymap
+    assert "Control-L" not in viewer.keymap
     ImageJWidget(viewer)
-    assert "L" in viewer.keymap
+    assert "Control-L" in viewer.keymap
     # TODO: I can't seem to figure out how to assert that pressing 'L'
     # sets the focus of the search bar.
     # Typing viewer.keymap['L'](viewer) does nothing. :(

--- a/tests/test_ImageJWidget.py
+++ b/tests/test_ImageJWidget.py
@@ -1,4 +1,5 @@
 import pytest
+from napari import Viewer
 from qtpy.QtWidgets import (
     QAbstractItemView,
     QHBoxLayout,
@@ -95,9 +96,7 @@ def example_info(ij):
 jc = JavaClasses()
 
 
-def test_button_param_regression(
-    ij, example_info: "jc.ModuleInfo", imagej_widget: ImageJWidget
-):
+def test_button_param_regression(ij, imagej_widget: ImageJWidget):
     plugins = ij.get("org.scijava.plugin.PluginService")
     searcher = plugins.getPlugin(jc.ModuleSearcher, jc.Searcher).createInstance()
     ij.context().inject(searcher)
@@ -128,3 +127,14 @@ def test_button_param_regression(
     )
     assert button_params[4][0] == "Batch"
     assert button_params[4][0] not in imagej_widget.highlighter.tooltips
+
+
+def test_keymaps(make_napari_viewer):
+    """Tests that 'L' is added to the keymap by ImageJWidget"""
+    viewer: Viewer = make_napari_viewer()
+    assert "L" not in viewer.keymap
+    ImageJWidget(viewer)
+    assert "L" in viewer.keymap
+    # TODO: I can't seem to figure out how to assert that pressing 'L'
+    # sets the focus of the search bar.
+    # Typing viewer.keymap['L'](viewer) does nothing. :(

--- a/tests/test_ImageJWidget.py
+++ b/tests/test_ImageJWidget.py
@@ -156,30 +156,6 @@ def test_result_single_click(make_napari_viewer, qtbot):
     )
     assert len(imagej_widget.highlighter.focused_action_buttons) == 5
 
-    # Test double click spawns the widget
-
-
-def test_result_double_click(make_napari_viewer, qtbot):
-    viewer: Viewer = make_napari_viewer()
-    imagej_widget: ImageJWidget = ImageJWidget(viewer)
-    viewer
-    # Test double click spawns the widget
-    assert len(viewer.window._dock_widgets) == 0
-    imagej_widget.results._search("Frangi")
-    item = imagej_widget.results._tables[0].item(0, 0)
-    assert item is not None
-    rect = imagej_widget.results._tables[0].visualItemRect(item)
-    # HACK: For some reason, we need to click before a double click.
-    # This seems to be the issue described in
-    # https://stackoverflow.com/questions/46795224/qlistwidget-doesnt-recognize-signals-from-qtestmousedclick
-    qtbot.mouseClick(
-        imagej_widget.results._tables[0].viewport(), Qt.LeftButton, pos=rect.center()
-    )
-    qtbot.mouseDClick(
-        imagej_widget.results._tables[0].viewport(), Qt.LeftButton, pos=rect.center()
-    )
-    assert len(viewer.window._dock_widgets) == 1
-
 
 def selected_row_index(table: QTableWidget):
     rows = table.selectionModel().selectedRows()

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -22,6 +22,7 @@ from napari.types import LayerDataTuple
 from napari_imagej import _module_utils
 from napari_imagej._ptypes import TypeMappings, _supported_styles
 from napari_imagej.setup_imagej import JavaClasses
+from napari_imagej.widget import ImageJWidget
 
 
 class JavaClassesTest(JavaClasses):
@@ -970,3 +971,11 @@ def test_execute_function_with_params(make_napari_viewer, ij):
 
     _module_utils._execute_function_with_params(viewer, params, func)
     assert len(viewer.layers) == 1
+
+
+def test_convert_searchResult_to_info(imagej_widget: ImageJWidget, ij):
+    searchers = imagej_widget.results.searchers
+    for searcher in searchers:
+        result = searcher.search("f", True)[0]
+        info = _module_utils.convert_searchResult_to_info(result)
+        assert isinstance(info, jc.ModuleInfo)


### PR DESCRIPTION
This PR makes a couple keyboard/mouse behavior changes:
* Focuses the search bar using `L` keybinding
* Double clicking a search result functions equivalently to pushing the first button (i.e. running the first search action). We should consider hardcoding it to a particular search action name.
* Using the up/down arrow keys while focused on the widget allows the user to traverse the search results. Hitting enter on any search result functions equivalently to double clicking the result.

TODO: Inserting time series data seems to break the `L` keybinding. Need to investigate more. Can you replicate @ctrueden @hinerm?

Closes #37