### PR TITLE
Support enum like types semi extensibly

### DIFF
--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from inspect import Parameter, Signature, signature
+from inspect import Parameter, Signature, _empty, signature
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from magicgui.widgets import Container, Label, LineEdit, Widget, request_values
@@ -422,20 +422,14 @@ def _param_default_or_none(input: "jc.ModuleItem") -> Optional[Any]:
     Gets the Python function's default value, if it exists, for input.
     """
     default = input.getDefaultValue()
-    if default is not None:
-        try:
-            return ij().py.from_java(default)
-        except Exception:
-            pass
-    if not input.isRequired():
-        return None
-    # We have to be careful here about passing a default
-    # Parameter uses an internal type to denote a required parameter.
-    # Passing anything EXCEPT that internal type will make that arugment default.
-    # Thus we need to only specify default if we have one.
-    from inspect import _empty
-
-    return _empty
+    if default is None and input.isRequired():
+        # We have to be careful here about passing a default of None
+        # Parameter uses an internal type to denote a required parameter.
+        return _empty
+    try:
+        return ij().py.from_java(default)
+    except Exception:
+        return default
 
 
 def _type_hint_for_module_item(input: "jc.ModuleItem") -> type:

--- a/src/napari_imagej/_module_utils.py
+++ b/src/napari_imagej/_module_utils.py
@@ -10,7 +10,7 @@ from napari.types import LayerDataTuple
 from napari.utils._magicgui import find_viewer_ancestor
 from scyjava import JavaIterable, JavaMap, JavaSet, Priority
 
-from napari_imagej._ptypes import TypeMappings, _supported_styles
+from napari_imagej._ptypes import TypeMappings, TypePlaceholders, _supported_styles
 from napari_imagej.setup_imagej import ij, jc, log_debug
 
 
@@ -31,6 +31,25 @@ def type_mappings():
     By lazily initializing this function, we minimize the time this thread is blocked.
     """
     return TypeMappings()
+
+
+@lru_cache(maxsize=None)
+def type_placeholders() -> Dict[Any, Any]:
+    """
+    Lazily creates a map of type placeholders.
+    This object is then cached upon function return,
+    effectively making this function a lazily initialized field.
+
+    This object should be lazily initialized as it will import java classes.
+    Those Java classes should not be imported until ImageJ has been able to set
+    up the JVM, adding its required JARs to the classpath. For that reason,
+    java class importing is done with java_import, which blocks UNTIL the imagej
+    gateway has been created (in a separate thread). Thus, prematurely calling this
+    function would block the calling thread.
+
+    By lazily initializing this function, we minimize the time this thread is blocked.
+    """
+    return TypePlaceholders()
 
 
 # List of Module Item Converters, along with their priority
@@ -71,6 +90,18 @@ def python_type_of(module_item: "jc.ModuleItem"):
             "or file an issue at https://github.com/imagej/napari-imagej!"
         )
     )
+
+
+@module_item_converter(priority=Priority.HIGH)
+def placeholder_converter(item: "jc.ModuleItem"):
+    """
+    Checks to see if this type can be satisfied by a placeholder.
+    For a placeholder to work, it MUST be a pure input.
+    This is because the python type has no functionality, as it is just an Enum choice.
+    """
+    if item.isInput() and not item.isOutput():
+        java_type = item.getType()
+        return type_placeholders().get(java_type, None)
 
 
 def _checkerUsingFunc(
@@ -393,10 +424,18 @@ def _param_default_or_none(input: "jc.ModuleItem") -> Optional[Any]:
     default = input.getDefaultValue()
     if default is not None:
         try:
-            default = ij().py.from_java(default)
+            return ij().py.from_java(default)
         except Exception:
             pass
-    return default
+    if not input.isRequired():
+        return None
+    # We have to be careful here about passing a default
+    # Parameter uses an internal type to denote a required parameter.
+    # Passing anything EXCEPT that internal type will make that arugment default.
+    # Thus we need to only specify default if we have one.
+    from inspect import _empty
+
+    return _empty
 
 
 def _type_hint_for_module_item(input: "jc.ModuleItem") -> type:
@@ -416,14 +455,7 @@ def _module_param(input: "jc.ModuleItem") -> Parameter:
     default = _param_default_or_none(input)
     type_hint = _type_hint_for_module_item(input)
 
-    # We have to be careful here about passing a default
-    # Parameter uses an internal type to denote a required parameter.
-    # Passing anything EXCEPT that internal type will make that arugment default.
-    # Thus we need to only specify default if we have one.
-    if default is not None:
-        return Parameter(name=name, kind=kind, default=default, annotation=type_hint)
-    else:
-        return Parameter(name=name, kind=kind, annotation=type_hint)
+    return Parameter(name=name, kind=kind, default=default, annotation=type_hint)
 
 
 def _modify_function_signature(

--- a/src/napari_imagej/_napari_converters.py
+++ b/src/napari_imagej/_napari_converters.py
@@ -4,13 +4,7 @@ import numpy as np
 from jpype import JArray, JDouble
 from labeling.Labeling import Labeling
 from napari.layers import Image, Labels, Points, Shapes
-from scyjava import (
-    Converter,
-    Priority,
-    add_java_converter,
-    add_py_converter,
-    when_jvm_starts,
-)
+from scyjava import Converter, Priority, add_java_converter, add_py_converter
 
 from napari_imagej import _ntypes
 from napari_imagej._ptypes import OutOfBoundsFactory, StructuringElement
@@ -313,25 +307,6 @@ def _realpointcollection_to_points(collection):
 
 
 # -- Enum(like)s -- #
-
-
-class EnumLikes(dict):
-    def __init__(self):
-        self.enum_likes = {}
-        self._put_after_jvm(
-            StructuringElement.FOUR_CONNECTED,
-            lambda: jc.StructuringElement.FOUR_CONNECTED,
-        )
-        self._put_after_jvm(
-            StructuringElement.EIGHT_CONNECTED,
-            lambda: jc.StructuringElement.EIGHT_CONNECTED,
-        )
-        self._put_after_jvm(
-            OutOfBoundsFactory.BORDER, lambda: jc.OutOfBoundsBorderFactory()
-        )
-
-    def _put_after_jvm(self, py_enum, j_enum):
-        when_jvm_starts(lambda: self.__setitem__(py_enum, j_enum))
 
 
 def _py_to_java_structuringElement(obj):

--- a/src/napari_imagej/_ptypes.py
+++ b/src/napari_imagej/_ptypes.py
@@ -1,9 +1,53 @@
 from collections import OrderedDict
+from enum import Enum, auto
 from typing import Dict, List
 
 from jpype import JBoolean, JByte, JChar, JDouble, JFloat, JInt, JLong, JShort
 
 from napari_imagej.setup_imagej import jc
+
+
+class StructuringElement(Enum):
+    FOUR_CONNECTED = auto()
+    EIGHT_CONNECTED = auto()
+
+
+class OutOfBoundsFactory(Enum):
+    BORDER = auto()
+    MIRROR_EXP_WINDOWING = auto()
+    MIRROR_SINGLE = auto()
+    MIRROR_DOUBLE = auto()
+    PERIODIC = auto()
+
+
+class TypePlaceholders(dict):
+    """
+    The definitive set of "placeholder"s for Java types.
+    This map allows us to determine the best placeholder for
+    Enum-like Java types. We define an Enum-like Java type as either:
+    1. An enum constant
+    2. An object with a no-args constant
+    """
+
+    def __init__(self):
+        # StructuringElements
+        self[jc.StructuringElement] = StructuringElement
+        # OutOfBoundsFactories
+        self[jc.OutOfBoundsFactory] = OutOfBoundsFactory
+
+    def get(self, key, default):
+        """
+        Checks if key is in this dictionary.
+
+        We must override this function to ensure that under the hood
+        this dictionary checks over its keys with == instead of "is".
+        "is" ensures two variables point to the same memory,
+        whereas "==" checks equality. We want the latter when checking classes.
+        """
+        for clazz in self.keys():
+            if clazz == key:
+                return self[clazz]
+        return default
 
 
 class TypeMappings:

--- a/src/napari_imagej/setup_imagej.py
+++ b/src/napari_imagej/setup_imagej.py
@@ -266,6 +266,30 @@ class JavaClasses(object):
         return "net.imglib2.IterableInterval"
 
     @blocking_import
+    def OutOfBoundsFactory(self):
+        return "net.imglib2.outofbounds.OutOfBoundsFactory"
+
+    @blocking_import
+    def OutOfBoundsBorderFactory(self):
+        return "net.imglib2.outofbounds.OutOfBoundsBorderFactory"
+
+    @blocking_import
+    def OutOfBoundsMirrorExpWindowingFactory(self):
+        return "net.imglib2.outofbounds.OutOfBoundsMirrorExpWindowingFactory"
+
+    @blocking_import
+    def OutOfBoundsMirrorFactory(self):
+        return "net.imglib2.outofbounds.OutOfBoundsMirrorFactory"
+
+    @blocking_import
+    def OutOfBoundsPeriodicFactory(self):
+        return "net.imglib2.outofbounds.OutOfBoundsPeriodicFactory"
+
+    @blocking_import
+    def OutOfBoundsRandomValueFactory(self):
+        return "net.imglib2.outofbounds.OutOfBoundsRandomValueFactory"
+
+    @blocking_import
     def RandomAccessible(self):
         return "net.imglib2.RandomAccessible"
 
@@ -280,6 +304,12 @@ class JavaClasses(object):
     @blocking_import
     def RealType(self):
         return "net.imglib2.type.numeric.RealType"
+
+    # ImgLib2-algorithm Types
+
+    @blocking_import
+    def StructuringElement(self):
+        return "net.imglib2.algorithm.labeling.ConnectedComponents.StructuringElement"
 
     # ImgLib2-roi Types
 

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -20,7 +20,7 @@ from napari.layers import Image, Labels, Layer, Points, Shapes
 from napari.types import LayerDataTuple
 
 from napari_imagej import _module_utils
-from napari_imagej._ptypes import TypeMappings, _supported_styles
+from napari_imagej._ptypes import OutOfBoundsFactory, TypeMappings, _supported_styles
 from napari_imagej.setup_imagej import JavaClasses
 from napari_imagej.widget import ImageJWidget
 
@@ -227,6 +227,26 @@ type_pairs = direct_match_pairs + convertible_match_pairs
 def test_python_type_of_IO(jtype, ptype):
     module_item = DummyModuleItem(jtype=jtype, isInput=True, isOutput=True)
     assert _module_utils.python_type_of(module_item) == ptype
+
+
+def test_python_type_of_placeholder_IO():
+    # Test that a pure input matches
+    module_item = DummyModuleItem(
+        jtype=jc.OutOfBoundsFactory, isInput=True, isOutput=False
+    )
+    assert _module_utils.python_type_of(module_item) == OutOfBoundsFactory
+
+    # Test that a mutable input does not match
+    module_item._isOutput = True
+    try:
+        _module_utils.python_type_of(module_item)
+        pytest.fail()
+    except ValueError:
+        pass
+
+    # Test that a pure output does not match the enum
+    module_item._isInput = False
+    assert _module_utils.python_type_of(module_item) == str
 
 
 @pytest.fixture

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -395,17 +395,27 @@ def test_param_annotation(imagej_widget):
 
 
 module_param_inputs = [
-    # default, required
+    # required, no default
     (
         DummyModuleItem(name="foo"),
         Parameter(name="foo", kind=Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
     ),
-    # default, not required
+    # not required, default
     (
         DummyModuleItem(name="foo", default="bar", isRequired=False),
         Parameter(
             name="foo",
             default="bar",
+            kind=Parameter.POSITIONAL_OR_KEYWORD,
+            annotation=Optional[str],
+        ),
+    ),
+    # not required, no default
+    (
+        DummyModuleItem(name="foo", isRequired=False),
+        Parameter(
+            name="foo",
+            default=None,
             kind=Parameter.POSITIONAL_OR_KEYWORD,
             annotation=Optional[str],
         ),

--- a/tests/test_napari_converters.py
+++ b/tests/test_napari_converters.py
@@ -6,8 +6,11 @@ from jpype import JArray, JDouble
 from labeling.Labeling import Labeling
 from napari.layers import Labels, Points, Shapes
 
+from napari_imagej._module_utils import python_type_of
+from napari_imagej._napari_converters import OutOfBoundsFactory, StructuringElement
 from napari_imagej._ntypes import _labeling_to_layer, _layer_to_labeling
 from napari_imagej.setup_imagej import jc
+from tests.test_module_utils import DummyModuleItem
 
 
 def assert_labels_equality(
@@ -625,3 +628,48 @@ def test_points_to_realpointcollection(ij, points):
     pts = [jc.RealPoint(p) for p in [p1, p2, p3]]
     for e, a in zip(pts, collection.points()):
         assert e == a
+
+
+# -- Enum(like)s -- #
+
+
+def test_StructuringElement_conversion(ij):
+    # Test python_type_of
+    assert (
+        python_type_of(DummyModuleItem(jtype=jc.StructuringElement))
+        == StructuringElement
+    )
+    # Test conversion
+    assert (
+        ij.py.to_java(StructuringElement.FOUR_CONNECTED)
+        == jc.StructuringElement.FOUR_CONNECTED
+    )
+    assert (
+        ij.py.to_java(StructuringElement.EIGHT_CONNECTED)
+        == jc.StructuringElement.EIGHT_CONNECTED
+    )
+
+
+def test_OutOfBoundsFactory_conversion(ij):
+    # Test python_type_of
+    assert (
+        python_type_of(DummyModuleItem(jtype=jc.OutOfBoundsFactory))
+        == OutOfBoundsFactory
+    )
+    # Test conversion
+    assert isinstance(
+        ij.py.to_java(OutOfBoundsFactory.BORDER), jc.OutOfBoundsBorderFactory
+    )
+    assert isinstance(
+        ij.py.to_java(OutOfBoundsFactory.MIRROR_EXP_WINDOWING),
+        jc.OutOfBoundsMirrorExpWindowingFactory,
+    )
+    assert isinstance(
+        ij.py.to_java(OutOfBoundsFactory.MIRROR_SINGLE), jc.OutOfBoundsMirrorFactory
+    )
+    assert isinstance(
+        ij.py.to_java(OutOfBoundsFactory.MIRROR_DOUBLE), jc.OutOfBoundsMirrorFactory
+    )
+    assert isinstance(
+        ij.py.to_java(OutOfBoundsFactory.PERIODIC), jc.OutOfBoundsPeriodicFactory
+    )


### PR DESCRIPTION
This PR adds support for the conversion of "enum-like" Java types into Python `enum`s. 

We define "enum-like" types to encompass both `enum`s *and* collections of interface implementations, each of which providing a no-argument constructor.

Users can then select the enums in the napari interface. When the module is run, a ScyJava `Converter` converts the Python `enum` choice into:
* The Java enum choice, if the Java type is an `Enum`
* A Java object generated from the no-arg ctor, if the Java type is an interface. 

Enum(like)s supported by this PR:
* `ConnectedComponents.StructuringElement`
* `OutOfBoundsFactory`

Closes #71