### PR TITLE
Use SearchService for asynchronous search

### DIFF
--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -233,7 +233,8 @@ class ResultTreeItem(QTreeWidgetItem):
 class SearcherTreeItem(QTreeWidgetItem):
     def __init__(self, searcher: "jc.Searcher"):
         super().__init__()
-        self.setText(0, ij().py.from_java(searcher.title()))
+        self.title = ij().py.from_java(searcher.title())
+        self.setText(0, self.title)
         self.setFlags(self.flags() & ~Qt.ItemIsSelectable)
         self._searcher = searcher
 
@@ -242,6 +243,7 @@ class SearcherTreeItem(QTreeWidgetItem):
         if results and len(results):
             self.addChildren([ResultTreeItem(r) for r in results])
         self.setExpanded(True)
+        self.setText(0, f"{self.title} ({len(results)})")
 
     def wraps(self, searcher: "jc.Searcher") -> bool:
         """Determines whether this class wraps searcher"""

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -230,6 +230,17 @@ class ResultTreeItem(QTreeWidgetItem):
         return self._result
 
 
+class SearchEventWrapper:
+    """
+    Python Class wrapping org.scijava.search.SearchEvent.
+    Needed for SearchTree.process, as signal types must be Python types.
+    """
+
+    def __init__(self, searcher: "jc.Searcher", results: List["jc.SearchResult"]):
+        self.searcher = searcher
+        self.results = [ResultTreeItem(r) for r in results]
+
+
 class SearcherTreeItem(QTreeWidgetItem):
     def __init__(self, searcher: "jc.Searcher"):
         super().__init__()
@@ -238,10 +249,10 @@ class SearcherTreeItem(QTreeWidgetItem):
         self.setFlags(self.flags() & ~Qt.ItemIsSelectable)
         self._searcher = searcher
 
-    def update(self, results: List["jc.SearchResult"]):
+    def update(self, results: List[SearchEventWrapper]):
         self.takeChildren()
         if results and len(results):
-            self.addChildren([ResultTreeItem(r) for r in results])
+            self.addChildren(results)
         self.setText(0, f"{self.title} ({len(results)})")
         self.setExpanded(len(results) < 10)
 

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -242,8 +242,8 @@ class SearcherTreeItem(QTreeWidgetItem):
         self.takeChildren()
         if results and len(results):
             self.addChildren([ResultTreeItem(r) for r in results])
-        self.setExpanded(True)
         self.setText(0, f"{self.title} ({len(results)})")
+        self.setExpanded(len(results) < 10)
 
 
 class SearchBar(QLineEdit):

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -6,7 +6,7 @@ from magicgui.widgets import ComboBox, Container, PushButton, request_values
 from napari import current_viewer
 from napari.layers import Layer
 from napari.utils._magicgui import get_layers
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QLineEdit, QTreeWidgetItem
 
 from napari_imagej.setup_imagej import ensure_jvm_started, ij, jc
@@ -274,9 +274,11 @@ class JLineEdit(QLineEdit):
     A QLineEdit that is disabled until the JVM is ready
     """
 
-    def __init__(self, on_key_down: Callable = lambda: None):
+    # Signal that identifies a down arrow pressed
+    floatBelow = Signal()
+
+    def __init__(self):
         super().__init__()
-        self._on_key_down = on_key_down
 
         # Set QtPy properties
         self.setText("Initializing ImageJ...Please Wait")
@@ -284,7 +286,7 @@ class JLineEdit(QLineEdit):
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Down:
-            self._on_key_down()
+            self.floatBelow.emit()
         else:
             super().keyPressEvent(event)
 

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -238,14 +238,10 @@ class SearcherTreeItem(QTreeWidgetItem):
         self._searcher = searcher
 
     def update(self, results: List["jc.SearchResult"]):
-        while self.childCount() > 0:
-            self.removeChild(self.child(0))
-        if results is None:
-            return
-        for result in results:
-            self.addChild(ResultTreeItem(result))
-        if len(results) > 0:
-            self.setExpanded(True)
+        self.takeChildren()
+        if results and len(results):
+            self.addChildren([ResultTreeItem(r) for r in results])
+        self.setExpanded(True)
 
     def wraps(self, searcher: "jc.Searcher") -> bool:
         """Determines whether this class wraps searcher"""

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -237,14 +237,19 @@ class SearcherTreeItem(QTreeWidgetItem):
         self.setFlags(self.flags() & ~Qt.ItemIsSelectable)
         self._searcher = searcher
 
-    def search(self, text: str):
-        results = self._searcher.search(text, True)
+    def update(self, results: List["jc.SearchResult"]):
         while self.childCount() > 0:
             self.removeChild(self.child(0))
+        if results is None:
+            return
         for result in results:
             self.addChild(ResultTreeItem(result))
         if len(results) > 0:
             self.setExpanded(True)
+
+    def wraps(self, searcher: "jc.Searcher") -> bool:
+        """Determines whether this class wraps searcher"""
+        return searcher.title().equals(self._searcher.title())
 
 
 class SearchBar(QLineEdit):

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -1,5 +1,5 @@
 import importlib
-from typing import Any, Callable, List
+from typing import Any, List
 
 from magicgui.types import ChoicesType
 from magicgui.widgets import ComboBox, Container, PushButton, request_values

--- a/src/napari_imagej/_helper_widgets.py
+++ b/src/napari_imagej/_helper_widgets.py
@@ -245,10 +245,6 @@ class SearcherTreeItem(QTreeWidgetItem):
         self.setExpanded(True)
         self.setText(0, f"{self.title} ({len(results)})")
 
-    def wraps(self, searcher: "jc.Searcher") -> bool:
-        """Determines whether this class wraps searcher"""
-        return searcher.title().equals(self._searcher.title())
-
 
 class SearchBar(QLineEdit):
     def __init__(self, on_key_down: Callable = lambda: None):

--- a/src/napari_imagej/setup_imagej.py
+++ b/src/napari_imagej/setup_imagej.py
@@ -232,6 +232,14 @@ class JavaClasses(object):
         return "org.scijava.search.Searcher"
 
     @blocking_import
+    def SearchEvent(self):
+        return "org.scijava.search.SearchEvent"
+
+    @blocking_import
+    def SearchListener(self):
+        return "org.scijava.search.SearchListener"
+
+    @blocking_import
     def SearchResult(self):
         return "org.scijava.search.SearchResult"
 

--- a/src/napari_imagej/widget.py
+++ b/src/napari_imagej/widget.py
@@ -255,7 +255,7 @@ class SearchTree(QTreeWidget):
 
     def _get_matching_item(self, searcher: "jc.Searcher") -> Optional[SearcherTreeItem]:
         name: str = ij().py.from_java(searcher.title())
-        matches = self.findItems(name, Qt.MatchExactly, 0)
+        matches = self.findItems(name, Qt.MatchStartsWith, 0)
         if len(matches) == 0:
             return None
         elif len(matches) == 1:

--- a/src/napari_imagej/widget.py
+++ b/src/napari_imagej/widget.py
@@ -25,8 +25,8 @@ from qtpy.QtWidgets import (
 
 from napari_imagej._flow_layout import FlowLayout
 from napari_imagej._helper_widgets import (
+    JLineEdit,
     ResultTreeItem,
-    SearchBar,
     SearcherTreeItem,
     SearchEventWrapper,
 )
@@ -125,28 +125,23 @@ class ImageJWidget(QWidget):
 
 
 class SearchbarWidget(QWidget):
+    """
+    A QWidget for streamlining ImageJ functionality searching
+    """
+
     def __init__(
         self,
     ):
         super().__init__()
         self.on_key_down = property()
-        self.bar: SearchBar = SearchBar(on_key_down=lambda: self.on_key_down())
+
+        # The main functionality is a search bar
+        self.bar: JLineEdit = JLineEdit(on_key_down=lambda: self.on_key_down())
+        Thread(target=self.bar.enable).start()
 
         # Set GUI options
         self.setLayout(QHBoxLayout())
         self.layout().addWidget(self.bar)
-
-        # Initialize the searchers, which will spin up an ImageJ gateway.
-        # By running this in a new thread,
-        # the GUI can be shown before the searchers are ready.
-        def enable_searchbar():
-            ensure_jvm_started()
-            # Enable the searchbar now that the searchers are ready
-            self.bar.setText("")
-            self.bar.setEnabled(True)
-
-        self.startup_thread = Thread(target=enable_searchbar)
-        self.startup_thread.start()
 
 
 class SearchTree(QTreeWidget):

--- a/src/napari_imagej/widget.py
+++ b/src/napari_imagej/widget.py
@@ -146,6 +146,8 @@ class SearchbarWidget(QWidget):
 
 class SearchTree(QTreeWidget):
 
+    # Signal used to update this widget with org.scijava.search.SearchResults.
+    # Given a SearchEventWrapper w, process.emit(w) will update the widget.
     process = Signal(SearchEventWrapper)
 
     def __init__(

--- a/src/napari_imagej/widget.py
+++ b/src/napari_imagej/widget.py
@@ -160,11 +160,9 @@ class SearchTree(QTreeWidget):
         self.setIndentation(self.indentation() // 2)
 
         # Start up the SearchResult producer/consumer chain
-        # The search
-        self.process.connect(self.update)
-
         self._producer_initializer = Thread(target=self._init_producer)
         self._producer_initializer.start()
+        self.process.connect(self.update)
 
     def wait_for_setup(self):
         """

--- a/src/napari_imagej/widget.py
+++ b/src/napari_imagej/widget.py
@@ -66,46 +66,46 @@ class ImageJWidget(QWidget):
         self.search.bar.textEdited.connect(self.results.search)
 
         # When clicking a result, focus it in the focus widget
-        def clickFunc(treeItem: QTreeWidgetItem):
+        def click(treeItem: QTreeWidgetItem):
             if isinstance(treeItem, ResultTreeItem):
                 self.focuser.focus(treeItem.result)
 
         # self.results.onClick = clickFunc
-        self.results.itemClicked.connect(clickFunc)
+        self.results.itemClicked.connect(click)
 
         # When double clicking a result,
         # focus it in the focus widget and run the first action
-        def doubleClickFunc(treeItem: QTreeWidgetItem):
+        def double_click(treeItem: QTreeWidgetItem):
             if isinstance(treeItem, ResultTreeItem):
                 self.focuser.run(treeItem.result)
 
-        self.results.on_double_click = doubleClickFunc
+        self.results.on_double_click = double_click
 
         # When pressing the up arrow on the topmost row in the results list,
         # go back up to the search bar
-        def keyUpFromResults():
+        def key_up_from_results():
             self.search.bar.setFocus()
 
-        self.results.key_above_results = keyUpFromResults
+        self.results.key_above_results = key_up_from_results
 
-        def searchBarKeyDown():
+        # When pressing the down arrow on the search bar,
+        # go to the first result item
+        def key_down_from_search_bar():
             self.search.bar.clearFocus()
             self.results.setFocus()
             self.results.setCurrentItem(self.results.topLevelItem(0))
 
-        self.search.on_key_down = searchBarKeyDown
+        self.search.on_key_down = key_down_from_search_bar
 
         # When pressing return on the search bar, focus the first result
         # in the results list and run it
-        def searchBarReturnFunc():
+        def return_search_bar():
             """Define the return behavior for this widget"""
             result = self.results.first_result()
             if result is not None:
                 self.focuser.run(result)
 
-        self.search.bar.returnPressed.connect(searchBarReturnFunc)
-
-        self.results.keyUpAction = lambda: self.search.bar.setFocus()
+        self.search.bar.returnPressed.connect(return_search_bar)
 
         # -- Final setup -- #
 
@@ -145,6 +145,11 @@ class SearchbarWidget(QWidget):
 
 
 class SearchEventWrapper:
+    """
+    Python Class wrapping org.scijava.search.SearchEvent.
+    Needed for SearchTree.process, as signal types must be Python types.
+    """
+
     def __init__(self, event: "jc.SearchEvent"):
         self.event = event
 

--- a/tests/test_ImageJWidget.py
+++ b/tests/test_ImageJWidget.py
@@ -129,12 +129,7 @@ def test_result_single_click(make_napari_viewer, qtbot):
     imagej_widget.results._wait_for_setup()
     assert len(imagej_widget.focuser.focused_action_buttons) == 0
     # Search something, then wait for the results to populate
-    qtbot.keyPress(imagej_widget.search.bar, Qt.Key_F)
-    qtbot.keyPress(imagej_widget.search.bar, Qt.Key_R)
-    qtbot.keyPress(imagej_widget.search.bar, Qt.Key_A)
-    qtbot.keyPress(imagej_widget.search.bar, Qt.Key_N)
-    qtbot.keyPress(imagej_widget.search.bar, Qt.Key_G)
-    qtbot.keyPress(imagej_widget.search.bar, Qt.Key_I)
+    imagej_widget.results.search("Frangi")
     tree = imagej_widget.results
     qtbot.waitUntil(lambda: tree.topLevelItemCount() > 0)
     qtbot.waitUntil(lambda: tree.topLevelItem(0).childCount() > 0)
@@ -142,7 +137,7 @@ def test_result_single_click(make_napari_viewer, qtbot):
     item = tree.topLevelItem(0).child(0)
     rect = tree.visualItemRect(item)
     qtbot.mouseClick(tree.viewport(), Qt.LeftButton, pos=rect.center())
-    qtbot.waitUntil(lambda: len(imagej_widget.focuser.focused_action_buttons) == 5)
+    qtbot.waitUntil(lambda: len(imagej_widget.focuser.focused_action_buttons) > 0)
 
 
 def _populate_tree(tree: SearchTree, qtbot):

--- a/tests/test_ImageJWidget.py
+++ b/tests/test_ImageJWidget.py
@@ -21,14 +21,6 @@ def test_widget_layout(imagej_widget: ImageJWidget):
     assert isinstance(imagej_widget.layout(), QVBoxLayout)
 
 
-def test_widget_searchbar_layout(imagej_widget: ImageJWidget):
-    """Tests basic features of the searchbar widget."""
-    searchbar: QWidget = imagej_widget.search
-    assert isinstance(searchbar.layout(), QHBoxLayout)
-    search_widget: QLineEdit = searchbar.findChild(QLineEdit)
-    assert search_widget is not None
-
-
 def test_widget_subwidget_layout(imagej_widget: ImageJWidget):
     """Tests the number and expected order of imagej_widget children"""
     subwidgets = imagej_widget.children()

--- a/tests/test_ImageJWidget.py
+++ b/tests/test_ImageJWidget.py
@@ -8,6 +8,7 @@ from napari_imagej.setup_imagej import JavaClasses
 from napari_imagej.widget import (
     FocusWidget,
     ImageJWidget,
+    ResultTreeItem,
     SearchbarWidget,
     SearcherTreeItem,
     SearchTree,
@@ -126,7 +127,7 @@ def test_result_single_click(make_napari_viewer, qtbot):
     # Assert that there are initially no buttons
     viewer: Viewer = make_napari_viewer()
     imagej_widget: ImageJWidget = ImageJWidget(viewer)
-    imagej_widget.results._wait_for_setup()
+    imagej_widget.results.wait_for_setup()
     assert len(imagej_widget.focuser.focused_action_buttons) == 0
     # Search something, then wait for the results to populate
     imagej_widget.results.search("Frangi")
@@ -158,13 +159,15 @@ def _populate_tree(tree: SearchTree, qtbot):
         def name(self):
             return self._name
 
-    tree._wait_for_setup()
+    tree.wait_for_setup()
     assert tree.topLevelItemCount() == 0
     searcher1 = SearcherTreeItem(DummySearcher("Commands"))
-    searcher1.update([DummySearchResult(s) for s in ("foo1", "foo2", "foo3")])
+    searcher1.update(
+        [ResultTreeItem(DummySearchResult(s)) for s in ("foo1", "foo2", "foo3")]
+    )
     tree.addTopLevelItem(searcher1)
     searcher2 = SearcherTreeItem(DummySearcher("Ops"))
-    searcher2.update([DummySearchResult(s) for s in ("bar1", "bar2")])
+    searcher2.update([ResultTreeItem(DummySearchResult(s)) for s in ("bar1", "bar2")])
     tree.addTopLevelItem(searcher2)
 
     # Wait for the tree to populate
@@ -175,7 +178,7 @@ def _populate_tree(tree: SearchTree, qtbot):
 
 def test_arrow_key_expansion(imagej_widget: ImageJWidget, qtbot):
     # Wait for the searchers to be ready
-    imagej_widget.results._wait_for_setup()
+    imagej_widget.results.wait_for_setup()
     # Search something
     imagej_widget.results.search("Frangi")
     tree = imagej_widget.results

--- a/tests/test_helper_widgets.py
+++ b/tests/test_helper_widgets.py
@@ -9,9 +9,9 @@ from napari.layers import Image
 from qtpy.QtCore import Qt
 
 from napari_imagej._helper_widgets import (
+    JLineEdit,
     MutableOutputWidget,
     ResultTreeItem,
-    SearchBar,
     SearcherTreeItem,
 )
 
@@ -157,6 +157,6 @@ def test_searcherTreeItem_regression():
 
 
 def test_searchBar_regression():
-    bar = SearchBar()
+    bar = JLineEdit()
     assert bar.text() == "Initializing ImageJ...Please Wait"
     assert not bar.isEnabled()

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -969,8 +969,8 @@ def test_execute_function_with_params(make_napari_viewer, ij):
 
 
 def test_convert_searchResult_to_info(imagej_widget: ImageJWidget, ij):
-    searchers = imagej_widget.results.searchers
-    for searcher in searchers:
+    for i in range(imagej_widget.results.topLevelItemCount()):
+        searcher = imagej_widget.results.topLevelItem(i)._searcher
         result = searcher.search("f", True)[0]
         info = _module_utils.convert_searchResult_to_info(result)
         assert isinstance(info, jc.ModuleInfo)

--- a/tests/test_module_utils.py
+++ b/tests/test_module_utils.py
@@ -474,7 +474,6 @@ def metadata_module_item(ij) -> DummyModuleItem:
     stepSize = ij.py.to_java(2.0)
     item.setStepSize(stepSize)
     label = ij.py.to_java("bar")
-    print(type(label))
     item.setLabel(label)
     description = ij.py.to_java("The foo.")
     item.setDescription(description)
@@ -783,16 +782,12 @@ from net.imglib2.img.array import ArrayImgs
 
 if d is None:
     d = ArrayImgs.unsignedBytes(10, 10)
-
-d[:, :] = 1
 """
 
 script_both_but_required: str = """
 #@BOTH Img(required=true) d
 
 from net.imglib2.img.array import ArrayImgs
-
-d[:, :] = 1
 """
 
 widget_parameterizations = [


### PR DESCRIPTION
This PR uses SciJava Search's [`SearchService`](https://github.com/scijava/scijava-search/blob/c28e3a4b7ba47e75ebd876c2660941cda9751f58/src/main/java/org/scijava/search/SearchService.java#L43) to provide the Search Results to the napari widget.

Benefits:
* Speed increase
* Avoids hardcoding `Searcher` implementations, and allows extensible addition of `Searcher`s.

Drawbacks:
* The asynchronous searching increases complexity

TODO:
* [x] Decide how to specify which `Searcher`s to use/not use
* [x] See if we can avoid removing all `SearchResult`s from the `SearcherTreeItem` every time we search
* [x] Determine the cause of unreproducible segfaults during searching

Closes #75