### PR TITLE
Conditional ImageJ Legacy imports and an imagej legacy CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           run: |
             python -m pytest -s -p no:faulthandler --color=yes
-
+    
   ensure-clean-code:
     runs-on: ubuntu-latest
     steps:
@@ -95,6 +95,42 @@ jobs:
         uses: isort/isort-action@master
         with:
           configuration: --check-only
+
+  test-imagej-legacy:
+    name: Test legacy inclusion
+    runs-on: ubuntu-latest
+    defaults:
+      # Steps that rely on the activated environment must be run with this shell setup.
+      # See https://github.com/marketplace/actions/setup-miniconda#important
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          # Create env with dev packages
+          auto-update-conda: true
+          python-version: 3.9
+          environment-file: dev-environment.yml
+          # Activate napari-imagej-dev environment
+          activate-environment: napari-imagej-dev
+          auto-activate-base: false
+          # Use mamba for faster setup
+          use-mamba: true
+          mamba-version: "*"
+
+      - name: Setup Qt libraries
+        uses: tlambert03/setup-qt-libs@v1
+
+      - name: Setup Testing Environment Variables
+        run: |
+          echo "NAPARI_IMAGEJ_INCLUDE_IMAGEJ_LEGACY=true" >> $GITHUB_ENV
+
+      - name: Test napari-imagej
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: |
+            conda run -n napari-imagej-dev --no-capture-output python -m pytest -s -p no:faulthandler --color=yes --cov-report=xml --cov=.
 
   conda-dev-test:
     name: Conda Setup & Code Coverage
@@ -121,13 +157,6 @@ jobs:
 
       - name: Setup Qt libraries
         uses: tlambert03/setup-qt-libs@v1
-
-      # strategy borrowed from vispy for installing opengl libs on windows
-      - name: Install Windows OpenGL
-        if: runner.os == 'Windows'
-        run: |
-          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
-          powershell gl-ci-helpers/appveyor/install_opengl.ps1
 
       - name: Test napari-imagej
         uses: GabrielBB/xvfb-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           run: |
             python -m pytest -s -p no:faulthandler --color=yes
-    
+
   ensure-clean-code:
     runs-on: ubuntu-latest
     steps:

--- a/src/napari_imagej/__init__.py
+++ b/src/napari_imagej/__init__.py
@@ -39,6 +39,7 @@ class _NapariImageJSettings(confuse.Configuration):
         # Don't use user settings during the tests
         testing = os.environ.get("NAPARI_IMAGEJ_TESTING", "no") == "yes"
         super().read(user=user and not testing, defaults=defaults)
+        super().set_env(prefix="NAPARI_IMAGEJ_")
         # -- VALIDATE SETTINGS -- #
         for key, value in self.items():
             self._validate_setting(key, value.get(), strict=False)

--- a/src/napari_imagej/__init__.py
+++ b/src/napari_imagej/__init__.py
@@ -39,6 +39,7 @@ class _NapariImageJSettings(confuse.Configuration):
         # Don't use user settings during the tests
         testing = os.environ.get("NAPARI_IMAGEJ_TESTING", "no") == "yes"
         super().read(user=user and not testing, defaults=defaults)
+        # Allow setting configuration using environment variables
         super().set_env(prefix="NAPARI_IMAGEJ_")
         # -- VALIDATE SETTINGS -- #
         for key, value in self.items():

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -21,7 +21,7 @@ from typing import Callable
 
 import imagej
 from jpype import JClass
-from scyjava import config, jimport
+from scyjava import config, jimport, jvm_started
 
 from napari_imagej import settings
 from napari_imagej.utilities.logging import log_debug
@@ -131,8 +131,12 @@ class JavaClasses(object):
 
         @property
         def inner(self):
-            ensure_jvm_started()
-            return jimport(func(self))
+            if not jvm_started():
+                raise Exception()
+            try:
+                return jimport(func(self))
+            except TypeError:
+                return None
 
         return inner
 

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -490,7 +490,7 @@ class JavaClasses(object):
 
     @blocking_import
     def ImagePlus(self):
-        return "net.imagej.ops.Initializable"
+        return "ij.ImagePlus"
 
     # ImageJ-Ops Types
 

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -486,6 +486,12 @@ class JavaClasses(object):
     def ROITree(self):
         return "net.imagej.roi.ROITree"
 
+    # ImageJ Types
+
+    @blocking_import
+    def ImagePlus(self):
+        return "net.imagej.ops.Initializable"
+
     # ImageJ-Ops Types
 
     @blocking_import

--- a/src/napari_imagej/types/mappings.py
+++ b/src/napari_imagej/types/mappings.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, List
 
 from jpype import JBoolean, JByte, JChar, JDouble, JFloat, JInt, JLong, JShort
 
+from napari_imagej import settings
 from napari_imagej.java import jc
 
 MAP_GENERATORS: List[Callable[[], Dict[Any, Any]]] = []
@@ -84,7 +85,7 @@ def labels() -> Dict[Any, Any]:
 
 @map_category
 def images() -> Dict[Any, Any]:
-    return {
+    ij2_map = {
         jc.RandomAccessibleInterval: "napari.layers.Image",
         jc.RandomAccessible: "napari.layers.Image",
         jc.IterableInterval: "napari.layers.Image",
@@ -92,11 +93,10 @@ def images() -> Dict[Any, Any]:
         jc.ImageDisplay: "napari.layers.Image",
         jc.Dataset: "napari.layers.Image",
         jc.DatasetView: "napari.layers.Image",
-        # TODO: remove 'add_legacy=False' -> struggles with LegacyService
-        # This change is waiting on a new pyimagej release
-        # java_import('ij.ImagePlus'):
-        # 'napari.types.ImageData'
     }
+    if settings["include_imagej_legacy"].get(bool):
+        ij2_map[jc.ImagePlus] = "napari.layers.Image"
+    return ij2_map
 
 
 @map_category

--- a/src/napari_imagej/utilities/_module_utils.py
+++ b/src/napari_imagej/utilities/_module_utils.py
@@ -206,21 +206,14 @@ def _napari_module_param_additions(
     return additional_params
 
 
-def _is_optional_arg(input: "jc.ModuleItem") -> bool:
+def _is_required_arg(input: "jc.ModuleItem") -> bool:
     """
-    Determines whether the ModuleInfo input is optional,
+    Determines whether the ModuleInfo input is required,
     as far as a python arg would be concerned.
-    For the python argument to be optional, we would need
-    EITHER a declaration of optionality by input.isRequired() == False,
-    OR a default value.
+    For the python argument to be required, we would need
+    BOTH input.isRequired() == True AND no default value.
     """
-    # TODO: I think this could be
-    # return input.isRequired() and input.getDefaultValue() is None
-    if not input.isRequired():
-        return False
-    if input.getDefaultValue() is not None:
-        return False
-    return True
+    return input.isRequired() and input.getDefaultValue() is None
 
 
 def _sink_optional_inputs(inputs: List["jc.ModuleItem"]) -> List["jc.ModuleItem"]:
@@ -230,7 +223,7 @@ def _sink_optional_inputs(inputs: List["jc.ModuleItem"]) -> List["jc.ModuleItem"
     """
 
     def sort_key(x):
-        return -1 if _is_optional_arg(x) else 1
+        return -1 if _is_required_arg(x) else 1
 
     return sorted(inputs, key=sort_key)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from napari import Viewer
 
 import napari_imagej
+from napari_imagej.java import ensure_jvm_started, ij_init
 from napari_imagej.widgets.menu import NapariImageJMenu
 from napari_imagej.widgets.napari_imagej import NapariImageJWidget
 
@@ -42,6 +43,14 @@ def preserve_user_settings():
         # After the test, remove the file
         if os.path.exists(user_path):
             os.remove(user_path)
+
+
+@pytest.fixture(autouse=True)
+def launch_imagej():
+    """Fixture ensuring any changes made earlier to the settings are reversed"""
+    ij_init()
+    ensure_jvm_started()
+    yield
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def preserve_user_settings():
 
 @pytest.fixture(autouse=True)
 def launch_imagej():
-    """Fixture ensuring any changes made earlier to the settings are reversed"""
+    """Fixture ensuring that ImageJ is running before any tests run"""
     ij_init()
     ensure_jvm_started()
     yield

--- a/tests/types/test_converters.py
+++ b/tests/types/test_converters.py
@@ -235,9 +235,9 @@ def test_ellipse_layer_to_mask(ij, ellipse_layer):
     # Assert dimensionality
     assert j_mask.numDimensions() == 2
     # Assert center position
-    center = j_mask.center().positionAsDoubleArray()
-    center = ij.py.from_java(center)
-    assert center == [30, 30]
+    j_center = j_mask.center().positionAsDoubleArray()
+    py_center = ij.py.from_java(j_center)
+    assert np.array_equal(j_center, py_center)
     # Assert semi-axis lengths
     assert j_mask.semiAxisLength(0) == 10
     assert j_mask.semiAxisLength(1) == 10
@@ -298,9 +298,9 @@ def test_rectangle_layer_to_mask_box(ij, rectangle_layer_axis_aligned):
     # Assert dimensionality
     assert j_mask.numDimensions() == 2
     # Assert center position
-    center = j_mask.center().positionAsDoubleArray()
-    center = ij.py.from_java(center)
-    assert center == [20, 20]
+    j_center = j_mask.center().positionAsDoubleArray()
+    py_center = ij.py.from_java(j_center)
+    assert np.array_equal(j_center, py_center)
     # Assert side lengths
     assert j_mask.sideLength(0) == 20
     assert j_mask.sideLength(1) == 20
@@ -422,9 +422,9 @@ def test_line_layer_to_mask(ij, line_layer):
     # Assert endpoints
     arr = JArray(JDouble)(2)
     j_mask.endpointOne().localize(arr)
-    assert ij.py.from_java(arr) == [0, 0]
+    assert np.array_equal(ij.py.from_java(arr), arr)
     j_mask.endpointTwo().localize(arr)
-    assert ij.py.from_java(arr) == [4, -4]
+    assert np.array_equal(ij.py.from_java(arr), arr)
     # Test some points
     _point_assertion(j_mask, [0, 0], True)
     _point_assertion(j_mask, [4, -4], True)
@@ -489,7 +489,7 @@ def test_path_layer_to_mask(ij, path_layer):
     actual = j_mask.vertices()
     for e, a in zip(expected, actual):
         a.localize(arr)
-        assert ij.py.from_java(arr) == e
+        assert np.array_equal(ij.py.from_java(arr), e)
     # Test some points
     _point_assertion(j_mask, [0, 0], True)
     _point_assertion(j_mask, [2, -2], True)
@@ -563,9 +563,9 @@ def test_multiple_layer_to_masks(ij, multiple_layer):
     # Assert dimensionality
     assert rois[0].numDimensions() == 2
     # Assert center position
-    center = rois[0].center().positionAsDoubleArray()
-    center = ij.py.from_java(center)
-    assert center == [30, 30]
+    j_center = rois[0].center().positionAsDoubleArray()
+    py_center = ij.py.from_java(j_center)
+    assert np.array_equal(py_center, j_center)
     # Assert semi-axis lengths
     assert rois[0].semiAxisLength(0) == 10
     assert rois[0].semiAxisLength(1) == 10
@@ -574,9 +574,9 @@ def test_multiple_layer_to_masks(ij, multiple_layer):
     # Assert dimensionality
     assert rois[1].numDimensions() == 2
     # Assert center position
-    center = rois[1].center().positionAsDoubleArray()
-    center = ij.py.from_java(center)
-    assert center == [20, 20]
+    j_center = rois[1].center().positionAsDoubleArray()
+    py_center = ij.py.from_java(j_center)
+    assert np.array_equal(py_center, j_center)
     # Assert side lengths
     assert rois[1].sideLength(0) == 20
     assert rois[1].sideLength(1) == 20

--- a/tests/utilities/test_module_utils.py
+++ b/tests/utilities/test_module_utils.py
@@ -98,38 +98,36 @@ def test_preprocess_remaining_inputs(preresolved_module):
         assert preresolved_module.isInputResolved(input.getName())
 
 
-example_inputs = [
+def test_resolvable_or_required():
     # Resolvable, required
-    (DummyModuleItem(), True),
+    assert _module_utils._resolvable_or_required(DummyModuleItem(jtype=jc.String))
     # Resolvable, not required
-    (DummyModuleItem(isRequired=False), True),
+    assert _module_utils._resolvable_or_required(
+        DummyModuleItem(jtype=jc.String, isRequired=False)
+    )
     # Not resolvable, required
-    (DummyModuleItem(jtype=jc.System), True),
+    assert _module_utils._resolvable_or_required(DummyModuleItem(jtype=jc.System))
     # Not resolvable, not required
-    (DummyModuleItem(jtype=jc.System, isRequired=False), False),
-]
+    assert not _module_utils._resolvable_or_required(
+        DummyModuleItem(jtype=jc.System, isRequired=False)
+    )
 
 
-@pytest.mark.parametrize("input, expected", example_inputs)
-def test_resolvable_or_required(input, expected):
-    assert expected == _module_utils._resolvable_or_required(input)
-
-
-is_non_default_example_inputs = [
+def test_is_non_default():
     # default, required
-    (DummyModuleItem(default="foo"), False),
+    assert not _module_utils._is_optional_arg(
+        DummyModuleItem(jtype=jc.String, default="foo")
+    )
     # default, not required
-    (DummyModuleItem(default="foo", isRequired=False), False),
+    assert not _module_utils._is_optional_arg(
+        DummyModuleItem(jtype=jc.String, default="foo", isRequired=False)
+    )
     # not default, required
-    (DummyModuleItem(), True),
+    assert _module_utils._is_optional_arg(DummyModuleItem(jtype=jc.String))
     # not default, not required
-    (DummyModuleItem(isRequired=False), False),
-]
-
-
-@pytest.mark.parametrize("input, expected", is_non_default_example_inputs)
-def test_is_non_default(input, expected):
-    assert expected == _module_utils._is_optional_arg(input)
+    assert not _module_utils._is_optional_arg(
+        DummyModuleItem(jtype=jc.String, isRequired=False)
+    )
 
 
 def test_sink_optional_inputs():
@@ -180,39 +178,35 @@ def test_param_annotation(imagej_widget):
     assert_item_annotation(jc.String, Optional[str], False)
 
 
-module_param_inputs = [
-    # required, no default
-    (
-        DummyModuleItem(name="foo"),
-        Parameter(name="foo", kind=Parameter.POSITIONAL_OR_KEYWORD, annotation=str),
-    ),
-    # not required, default
-    (
-        DummyModuleItem(name="foo", default="bar", isRequired=False),
-        Parameter(
-            name="foo",
-            default="bar",
-            kind=Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=Optional[str],
-        ),
-    ),
-    # not required, no default
-    (
-        DummyModuleItem(name="foo", isRequired=False),
-        Parameter(
-            name="foo",
-            default=None,
-            kind=Parameter.POSITIONAL_OR_KEYWORD,
-            annotation=Optional[str],
-        ),
-    ),
-]
+def test_module_param():
+    # required, non default parameter
+    module_item = DummyModuleItem(jtype=jc.String, name="foo")
+    expected = Parameter(
+        name="foo", kind=Parameter.POSITIONAL_OR_KEYWORD, annotation=str
+    )
+    assert expected == _module_utils._module_param(module_item)
 
+    # not required, default parameter
+    module_item = DummyModuleItem(
+        jtype=jc.String, name="foo", default="bar", isRequired=False
+    )
+    expected = Parameter(
+        name="foo",
+        default="bar",
+        kind=Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=Optional[str],
+    )
+    assert expected == _module_utils._module_param(module_item)
 
-@pytest.mark.parametrize("input, expected", module_param_inputs)
-def test_module_param(input, expected):
-    actual = _module_utils._module_param(input)
-    assert actual == expected
+    # not required, non default parameter
+    module_item = DummyModuleItem(jtype=jc.String, name="foo", isRequired=False)
+    expected = Parameter(
+        name="foo",
+        default=None,
+        kind=Parameter.POSITIONAL_OR_KEYWORD,
+        annotation=Optional[str],
+    )
+    assert expected == _module_utils._module_param(module_item)
 
 
 def test_add_param_metadata():
@@ -493,7 +487,7 @@ widget_parameterizations = [
     (script_one_layer_two_widget, 1, 2, []),
     (script_two_layer_two_widget, 2, 2, []),
     # No layers returned, the required BOTH is just updated
-    (script_both_but_required, 0, 0, [jc.ArrayImgs.bytes(10, 10)]),
+    (script_both_but_required, 0, 0, [numpy.zeros((10, 10), dtype=numpy.int8)]),
     # One layer returned as we create the optional input internally
     (script_both_but_optional, 1, 0, [None]),
 ]

--- a/tests/utilities/test_module_utils.py
+++ b/tests/utilities/test_module_utils.py
@@ -113,19 +113,19 @@ def test_resolvable_or_required():
     )
 
 
-def test_is_non_default():
+def test_is_required_arg():
     # default, required
-    assert not _module_utils._is_optional_arg(
+    assert not _module_utils._is_required_arg(
         DummyModuleItem(jtype=jc.String, default="foo")
     )
     # default, not required
-    assert not _module_utils._is_optional_arg(
+    assert not _module_utils._is_required_arg(
         DummyModuleItem(jtype=jc.String, default="foo", isRequired=False)
     )
     # not default, required
-    assert _module_utils._is_optional_arg(DummyModuleItem(jtype=jc.String))
+    assert _module_utils._is_required_arg(DummyModuleItem(jtype=jc.String))
     # not default, not required
-    assert not _module_utils._is_optional_arg(
+    assert not _module_utils._is_required_arg(
         DummyModuleItem(jtype=jc.String, isRequired=False)
     )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -179,14 +179,14 @@ class DummyModuleItem:
     def __init__(
         self,
         name="",
-        jtype=jc.String,
+        jtype=None,
         isRequired=True,
         isInput=True,
         isOutput=False,
         default=None,
     ):
         self._name = name
-        self._jtype = jtype
+        self._jtype = jtype if jtype is not None else jc.String
         self._isRequired = isRequired
         self._isInput = isInput
         self._isOutput = isOutput

--- a/tests/widgets/test_parameter_widgets.py
+++ b/tests/widgets/test_parameter_widgets.py
@@ -130,60 +130,54 @@ def test_mutable_output_add_new_image(
     assert foo is output_widget.value
 
 
-real_type_widget_params = [
-    (jc.BitType),
-    (jc.BoolType),
-    (jc.ByteType),
-    (jc.UnsignedByteType),
-    (jc.ShortType),
-    (jc.UnsignedShortType),
-    (jc.IntType),
-    (jc.UnsignedIntType),
-    (jc.LongType),
-    (jc.UnsignedLongType),
-    (jc.FloatType),
-    (jc.DoubleType),
-]
+def test_realType():
+    real_types = [
+        (jc.BitType),
+        (jc.BoolType),
+        (jc.ByteType),
+        (jc.UnsignedByteType),
+        (jc.ShortType),
+        (jc.UnsignedShortType),
+        (jc.IntType),
+        (jc.UnsignedIntType),
+        (jc.LongType),
+        (jc.UnsignedLongType),
+        (jc.FloatType),
+        (jc.DoubleType),
+    ]
+    for real_type in real_types:
+        type_instance = real_type.class_.newInstance()
+        widget = numeric_type_widget_for(real_type.class_)()
+        min_val = type_instance.getMinValue()
+        max_val = type_instance.getMaxValue()
+        # If the type is not a boolean, it will have min and max values
+        if issubclass(real_type.class_, jc.BooleanType):
+            assert not hasattr(widget, "min")
+            assert not hasattr(widget, "min")
+        else:
+            # Integer widget has a bound on the minimum and maximum values
+            if issubclass(real_type.class_, jc.IntegerType):
+                min_val = max(type_instance.getMinValue(), -(2**31))
+                max_val = min(type_instance.getMaxValue(), (2**31 - 1))
+            assert min_val == widget.min
+            assert max_val == widget.max
+        assert isinstance(widget.value, real_type)
 
 
-@pytest.mark.parametrize(argnames="realtype", argvalues=real_type_widget_params)
-def test_realType(realtype):
-    type_instance = realtype.class_.newInstance()
-    widget = numeric_type_widget_for(realtype.class_)()
-    min_val = type_instance.getMinValue()
-    max_val = type_instance.getMaxValue()
-    # If the type is not a boolean, it will have min and max values
-    if issubclass(realtype.class_, jc.BooleanType):
-        assert not hasattr(widget, "min")
-        assert not hasattr(widget, "min")
-    else:
-        # Integer widget has a bound on the minimum and maximum values
-        if issubclass(realtype.class_, jc.IntegerType):
-            min_val = max(type_instance.getMinValue(), -(2**31))
-            max_val = min(type_instance.getMaxValue(), (2**31 - 1))
-        assert min_val == widget.min
-        assert max_val == widget.max
-    assert isinstance(widget.value, realtype)
-
-
-real_type_iface_widget_params = [
-    (jc.RealType, jc.DoubleType),
-    (jc.IntegerType, jc.LongType),
-    (jc.NumericType, jc.DoubleType),
-    (jc.BooleanType, jc.BitType),
-]
-
-
-@pytest.mark.parametrize(
-    argnames=["iface", "realtype"], argvalues=real_type_iface_widget_params
-)
-def test_realType_ifaces(iface, realtype):
-    widget_iface = numeric_type_widget_for(iface.class_)()
-    widget_impl = numeric_type_widget_for(realtype.class_)()
-    if issubclass(iface.class_, jc.BooleanType):
-        assert not hasattr(widget_iface, "min")
-        assert not hasattr(widget_iface, "max")
-    else:
-        assert widget_iface.min == widget_impl.min
-        assert widget_iface.max == widget_impl.max
-    assert isinstance(widget_iface.value, realtype)
+def test_realType_ifaces():
+    iface_impl_tuples = [
+        (jc.RealType, jc.DoubleType),
+        (jc.IntegerType, jc.LongType),
+        (jc.NumericType, jc.DoubleType),
+        (jc.BooleanType, jc.BitType),
+    ]
+    for iface, impl in iface_impl_tuples:
+        widget_iface = numeric_type_widget_for(iface.class_)()
+        widget_impl = numeric_type_widget_for(impl.class_)()
+        if issubclass(iface.class_, jc.BooleanType):
+            assert not hasattr(widget_iface, "min")
+            assert not hasattr(widget_iface, "max")
+        else:
+            assert widget_iface.min == widget_impl.min
+            assert widget_iface.max == widget_impl.max
+        assert isinstance(widget_iface.value, impl)


### PR DESCRIPTION
This PR does two things:
* Re-introduces legacy type mappings, conditional on the presence of imagej-legacy.
* Adds a Github actions job for testing that imagej-legacy works.

TODO: Do the imports actually need to be conditional? Or can we just always have them there, but know that they'll fail if someone tries using them without imagej legacy...

Closes #94 