### PR TITLE
Order search results by priority

### DIFF
--- a/src/napari_imagej/widgets/result_tree.py
+++ b/src/napari_imagej/widgets/result_tree.py
@@ -43,10 +43,17 @@ class SearcherTreeItem(QTreeWidgetItem):
         super().__init__()
         self.title = ij().py.from_java(searcher.title())
         self._searcher = searcher
+        # Finding the priority is tricky - Searchers don't know their priority
+        # To find it we have to ask the pluginService.
+        plugin_info = ij().plugin().getPlugin(searcher.getClass())
+        self.priority = plugin_info.getPriority() if plugin_info else 0.0
 
         # Set QtPy properties
         self.setText(0, self.title)
         self.setFlags(self.flags() & ~Qt.ItemIsSelectable)
+
+    def __lt__(self, other):
+        return self.priority > other.priority
 
     def update(self, results: List[SearchResultTreeItem]):
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,6 +28,10 @@ class JavaClassesTest(JavaClasses):
         return "net.imglib2.type.numeric.integer.ByteType"
 
     @JavaClasses.blocking_import
+    def ClassesSearcher(self):
+        return "org.scijava.search.classes.ClassesSearcher"
+
+    @JavaClasses.blocking_import
     def ClassSearchResult(self):
         return "org.scijava.search.classes.ClassSearchResult"
 
@@ -66,6 +70,10 @@ class JavaClassesTest(JavaClasses):
     @JavaClasses.blocking_import
     def ItemVisibility(self):
         return "org.scijava.ItemVisibility"
+
+    @JavaClasses.blocking_import
+    def ModuleSearcher(self):
+        return "org.scijava.search.module.ModuleSearcher"
 
     @JavaClasses.blocking_import
     def ScriptInfo(self):
@@ -109,6 +117,9 @@ class DummySearcher:
     def title(self):
         return self._title
 
+    def getClass(self):
+        return jc.Searcher.class_
+
 
 class DummySearchEvent:
     """
@@ -124,6 +135,11 @@ class DummySearchEvent:
 
     def results(self):
         return self._results
+
+
+class DummySearchResult(object):
+    def name(self):
+        return "This is not a Search Result"
 
 
 class DummyModuleInfo:

--- a/tests/widgets/test_napari_imagej.py
+++ b/tests/widgets/test_napari_imagej.py
@@ -93,3 +93,15 @@ def test_searchbar_results_transitions(
     # See https://doc.qt.io/qt-5/qwidget.html#setFocus
     asserter(lambda: not imagej_widget.search.bar.isVisible())
     asserter(lambda: QApplication.focusWidget() is None)
+
+
+def test_search_tree_ordering(imagej_widget, asserter):
+    """
+    Ensures that the Searchers appear in priority order in
+    the search tree
+    """
+    results = imagej_widget.result_tree
+    results.search("F")
+    asserter(lambda: results.topLevelItemCount() > 2)
+    for i in range(results.topLevelItemCount() - 1):
+        assert results.topLevelItem(i).priority >= results.topLevelItem(i + 1).priority

--- a/tests/widgets/test_result_tree.py
+++ b/tests/widgets/test_result_tree.py
@@ -9,7 +9,7 @@ from napari_imagej.widgets.result_tree import (
     SearchResultTree,
     SearchResultTreeItem,
 )
-from tests.utils import DummySearcher, DummySearchEvent, jc
+from tests.utils import DummySearcher, DummySearchEvent, DummySearchResult, jc
 from tests.widgets.widget_utils import _populate_tree
 
 
@@ -68,10 +68,6 @@ def test_searchers_disappear(results_tree: SearchResultTree, asserter):
 
 
 def test_resultTreeItem_regression():
-    class DummySearchResult(object):
-        def name(self):
-            return "This is not a Search Result"
-
     dummy = DummySearchResult()
     item = SearchResultTreeItem(dummy)
     assert item.result == dummy
@@ -79,11 +75,7 @@ def test_resultTreeItem_regression():
 
 
 def test_searcherTreeItem_regression():
-    class DummySearcher(object):
-        def title(self):
-            return "This is not a Searcher"
-
-    dummy = DummySearcher()
+    dummy = DummySearcher("This is not a Searcher")
     item = SearcherTreeItem(dummy)
     assert item._searcher == dummy
     assert (


### PR DESCRIPTION
I feel like @hinerm mentioned this to me...somewhere :sweat_smile: 

This PR ensures that `Searcher`s are ordered by their `@Plugin` priority within the results `QTreeWidget`. We also add a small test to ensure that at runtime the `Searchers` are ordered.