### PR TITLE
Enable configuration of SciJava Searchers

### DIFF
--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -265,10 +265,6 @@ class JavaClasses(object):
         return "org.scijava.module.ModuleItem"
 
     @blocking_import
-    def ModuleSearcher(self):
-        return "org.scijava.search.module.ModuleSearcher"
-
-    @blocking_import
     def PostprocessorPlugin(self):
         return "org.scijava.module.process.PostprocessorPlugin"
 

--- a/src/napari_imagej/utilities/_module_utils.py
+++ b/src/napari_imagej/utilities/_module_utils.py
@@ -614,9 +614,11 @@ def execute_function_modally(
     _execute_function_with_params(viewer, params, func)
 
 
-def info_for(search_result: "jc.SearchResult") -> "jc.ModuleInfo":
-    info = search_result.info()
-    # There is an extra step for Ops - we actually need the CommandInfo
-    if isinstance(info, jc.OpInfo):
-        info = info.cInfo()
-    return info
+def info_for(search_result: "jc.SearchResult") -> Optional["jc.ModuleInfo"]:
+    if hasattr(search_result, "info"):
+        info = search_result.info()
+        # There is an extra step for Ops - we actually need the CommandInfo
+        if isinstance(info, jc.OpInfo):
+            info = info.cInfo()
+        return info
+    return None

--- a/src/napari_imagej/widgets/result_runner.py
+++ b/src/napari_imagej/widgets/result_runner.py
@@ -128,6 +128,10 @@ class ResultRunner(QWidget):
 
             name = str(result.name())
             moduleInfo = info_for(result)
+            if not moduleInfo:
+                log_debug(f"Search Result {result} cannot be run!")
+                return []
+
             module = ij().module().createModule(moduleInfo)
 
             # preprocess using napari GUI

--- a/tests/utilities/test_module_utils.py
+++ b/tests/utilities/test_module_utils.py
@@ -14,7 +14,6 @@ from napari.layers import Image, Layer
 from napari_imagej.types.mappings import ptypes
 from napari_imagej.types.type_utils import _napari_layer_types
 from napari_imagej.utilities import _module_utils
-from napari_imagej.widgets.napari_imagej import NapariImageJWidget
 from tests.utils import DummyModuleItem, jc
 
 
@@ -667,9 +666,19 @@ def test_functionify_module_execution_result_regression(make_napari_viewer, ij):
     assert sig.return_annotation == List[Layer]
 
 
-def test_convert_searchResult_to_info(imagej_widget: NapariImageJWidget, ij):
-    for i in range(imagej_widget.result_tree.topLevelItemCount()):
-        searcher = imagej_widget.result_tree.topLevelItem(i)._searcher
-        result = searcher.search("f", True)[0]
-        info = _module_utils.info_for(result)
-        assert isinstance(info, jc.ModuleInfo)
+def test_info_for(ij):
+    # Case 1: An OpSearchResult
+    op_infos = ij.op().infos()
+    assert len(op_infos)
+    result = jc.OpSearchResult(ij.context(), list(op_infos)[0], "")
+    assert isinstance(_module_utils.info_for(result), jc.ModuleInfo)
+
+    # Case 2: A ModuleSearchResult
+    module_infos = ij.module().getModules()
+    assert len(module_infos)
+    result = jc.ModuleSearchResult(module_infos.get(0), "")
+    assert isinstance(_module_utils.info_for(result), jc.ModuleInfo)
+
+    # Case 3: A ClassSearchResult (no info)
+    result = jc.ClassSearchResult(jc.Double, "")
+    assert _module_utils.info_for(result) is None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,8 @@ A module containing testing utilities
 """
 from typing import List
 
+from jpype import JImplements, JOverride
+
 from napari_imagej.java import JavaClasses
 
 
@@ -72,8 +74,12 @@ class JavaClassesTest(JavaClasses):
         return "org.scijava.ItemVisibility"
 
     @JavaClasses.blocking_import
-    def ModuleSearcher(self):
-        return "org.scijava.search.module.ModuleSearcher"
+    def ModuleSearchResult(self):
+        return "org.scijava.search.module.ModuleSearchResult"
+
+    @JavaClasses.blocking_import
+    def OpSearchResult(self):
+        return "net.imagej.ops.search.OpSearchResult"
 
     @JavaClasses.blocking_import
     def ScriptInfo(self):
@@ -107,18 +113,26 @@ class JavaClassesTest(JavaClasses):
 jc = JavaClassesTest()
 
 
+@JImplements("org.scijava.search.Searcher", deferred=True)
 class DummySearcher:
+    """
+    Implementation of org.scijava.search.Searcher used for testing
+    """
+
     def __init__(self, title: str):
         self._title = title
 
+    @JOverride
     def search(self, text: str, fuzzy: bool):
         pass
 
-    def title(self):
+    @JOverride
+    def title(self) -> str:
         return self._title
 
+    @JOverride
     def getClass(self):
-        return jc.Searcher.class_
+        return jc.Searcher
 
 
 class DummySearchEvent:

--- a/tests/widgets/widget_utils.py
+++ b/tests/widgets/widget_utils.py
@@ -1,35 +1,47 @@
 """
 A module containing functionality useful for widget testing
 """
-from napari_imagej.widgets.result_tree import (
-    SearcherTreeItem,
-    SearchResultTree,
-    SearchResultTreeItem,
-)
-from tests.utils import DummySearcher, jc
+from typing import Optional
+
+from scyjava import Priority
+
+from napari_imagej.widgets.result_tree import SearcherTreeItem, SearchResultTree
+from tests.utils import DummySearcher, DummySearchEvent, jc
+
+
+def _searcher_tree_named(
+    tree: SearchResultTree, name: str
+) -> Optional[SearcherTreeItem]:
+    for i in range(tree.topLevelItemCount()):
+        if tree.topLevelItem(i).title.startswith(name):
+            return tree.topLevelItem(i)
+    return None
 
 
 def _populate_tree(tree: SearchResultTree, asserter):
-    tree.wait_for_setup()
-    assert tree.topLevelItemCount() == 0
-    searcher1 = SearcherTreeItem(DummySearcher("Commands"))
-    searcher1.update(
-        [
-            SearchResultTreeItem(jc.ClassSearchResult(c, ""))
-            for c in (jc.Short, jc.Integer, jc.Long)
-        ]
+    asserter(lambda: tree.topLevelItemCount() == 0)
+    # Add two searchers
+    searcher1 = DummySearcher("Test1")
+    item1 = SearcherTreeItem(searcher1, priority=Priority.LOW)
+    tree.insert.emit(item1)
+    searcher2 = DummySearcher("Test2")
+    item2 = SearcherTreeItem(searcher2, priority=Priority.HIGH)
+    tree.insert.emit(item2)
+    asserter(lambda: tree.topLevelItemCount() == 2)
+
+    # Update each searcher with data
+    tree.process.emit(
+        DummySearchEvent(
+            searcher1, [jc.ClassSearchResult(c, "") for c in (jc.Float, jc.Double)]
+        )
     )
-    tree.addTopLevelItem(searcher1)
-    searcher2 = SearcherTreeItem(DummySearcher("Ops"))
-    searcher2.update(
-        [
-            SearchResultTreeItem(jc.ClassSearchResult(c, ""))
-            for c in (jc.Float, jc.Double)
-        ]
+    tree.process.emit(
+        DummySearchEvent(
+            searcher2,
+            [jc.ClassSearchResult(c, "") for c in (jc.Short, jc.Integer, jc.Long)],
+        )
     )
-    tree.addTopLevelItem(searcher2)
 
     # Wait for the tree to populate
-    asserter(lambda: tree.topLevelItemCount() == 2)
     asserter(lambda: tree.topLevelItem(0).childCount() == 3)
     asserter(lambda: tree.topLevelItem(1).childCount() == 2)


### PR DESCRIPTION
This PR aligns the Search Results tree to look *even more* like the ImageJ2/Fiji Search results:
![image](https://user-images.githubusercontent.com/29754838/195193963-520e6fd8-b0c7-4c76-926c-64d92b31c1b4.png)
Now, each `Searcher` registered in the `PluginService` is mapped to a top level item of the results. When its check box is checked, that `Searcher` becomes enabled from the `SearchService`. This has the side effect of registering that `Searcher`s "enabled-ness" with the `PrefService`, meaning that (un)checking a `Searcher` in napari-imagej will propagate the change to any ImageJ2 installation (and the same goes for the other direction).

Points of discussion:
* Does this change solve #114? Not *really*, but it does make fixing the change *much* easier.

TODO:
* [ ] Better comments within the files
* [x] Test the change
* [x] Determine whether we are solving that issue.
