### PR TITLE
Improve napari-imagej's Number/RealType support

### DIFF
--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -346,6 +346,10 @@ class JavaClasses(object):
         return "java.lang.Long"
 
     @blocking_import
+    def Number(self):
+        return "java.lang.Number"
+
+    @blocking_import
     def Short(self):
         return "java.lang.Short"
 

--- a/src/napari_imagej/types/widget_mappings.py
+++ b/src/napari_imagej/types/widget_mappings.py
@@ -66,10 +66,8 @@ def preferred_widget_for(
 def _numeric_type_preference(
     item: "jc.ModuleItem", type_hint: Union[type, str]
 ) -> Optional[Union[type, str]]:
-    # We only care about mutable outputs
-    if item.isInput() and not item.isOutput():
-        if issubclass(item.getType(), jc.NumericType):
-            return numeric_type_widget_for(item.getType())
+    if issubclass(item.getType(), jc.NumericType):
+        return numeric_type_widget_for(item.getType())
 
 
 @_widget_preference

--- a/tests/utilities/test_module_utils.py
+++ b/tests/utilities/test_module_utils.py
@@ -141,7 +141,7 @@ def test_napari_param_new_window_checkbox():
 
 def assert_item_annotation(jtype, ptype, isRequired):
     module_item = DummyModuleItem(jtype=jtype, isRequired=isRequired)
-    param_type = _module_utils._type_hint_for_module_item(module_item)
+    param_type = _module_utils.type_hint_for(module_item)
     assert param_type == ptype
 
 


### PR DESCRIPTION
This PR improves support for `RealType` I/O `Module` parameters.

Note that, because imagej-ops replaces these parameters with `Number`s, much of the work applies to both `RealType`s and `Number`s.

This PR relies on new releases of pyimagej *and* imagej-common, and would also benefit from a pom-scijava update to get the latest scijava-common version by default.