### PR TITLE
Enforce minimum java component versions

### DIFF
--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -2,12 +2,12 @@
 A module encapsulating access to Java functionality.
 
 Notable functions included in the module:
-    * ij_init()
-        - used to begin the creation of the ImageJ instance.
-    * ensure_jvm_started()
-        - used to block execution until the ImageJ instance is ready
+    * init_ij()
+        - used to create the ImageJ instance.
+    * init_ij_async()
+        - used to asynchronously create the ImageJ instance.
     * ij()
-        - used to access the ImageJ instance
+        - used to access the ImageJ instance. Calls init_ij() if necessary.
 
 Notable fields included in the module:
     * jc
@@ -27,9 +27,17 @@ from napari_imagej.utilities.logging import log_debug
 # -- ImageJ API -- #
 
 
-def init_ij():
+def init_ij() -> None:
     """
-    Begins the creation of our ImageJ instance.
+    Starts creating our ImageJ instance, and waits until it is ready.
+    """
+    init_ij_async()
+    initializer.wait()
+
+
+def init_ij_async():
+    """
+    Starts creating our ImageJ instance.
     """
     initializer.start()
 
@@ -39,16 +47,8 @@ def ij():
     Returns the ImageJ instance.
     If it isn't ready yet, blocks until it is ready.
     """
-    ensure_jvm_started()
-    return initializer.ij
-
-
-def ensure_jvm_started() -> None:
-    """
-    Blocks until the ImageJ instance is ready.
-    """
     init_ij()
-    initializer.wait()
+    return initializer.ij
 
 
 class ImageJInitializer(QThread):

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -94,27 +94,31 @@ class ImageJInitializer(QThread):
 
         # -- IMAGEJ CONFIG -- #
 
+        # ScyJava configuration
         # TEMP: Avoid issues caused by
         # https://github.com/imagej/pyimagej/issues/160
         config.add_repositories(
             {"scijava.public": "https://maven.scijava.org/content/groups/public"}
         )
         config.add_option(f"-Dimagej2.dir={settings['imagej_base_directory'].get(str)}")
-        log_debug("Completed JVM Configuration")
 
-        # Add converters
+        # PyImageJ configuration
+        ij_settings = {}
+        ij_settings["ij_dir_or_version_or_endpoint"] = settings[
+            "imagej_directory_or_endpoint"
+        ].get(str)
+        ij_settings["mode"] = settings["jvm_mode"].get(str)
+        ij_settings["add_legacy"] = settings["include_imagej_legacy"].get(bool)
+
+        # napari-imagej configuration
         from napari_imagej.types.converters import install_converters
 
         install_converters()
 
+        log_debug("Completed JVM Configuration")
+
         # Launch PyImageJ
-        self.ij = imagej.init(
-            ij_dir_or_version_or_endpoint=settings["imagej_directory_or_endpoint"].get(
-                str
-            ),
-            mode=settings["jvm_mode"].get(str),
-            add_legacy=settings["include_imagej_legacy"].get(bool),
-        )
+        self.ij = imagej.init(**ij_settings)
         # Validate PyImageJ
         self._validate_imagej()
         # Log initialization

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -196,7 +196,7 @@ class ImageJ_Callbacks(QObject):
         If ImageJ has not yet been initialized, the passed function is registered
         as a callback.
 
-        If ImageJ setup has already failed, this function does nothing
+        If ImageJ setup has already failed, the passed function will not be called.
 
         :param func: The behavior to execute
         """

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -3,7 +3,6 @@ The top-level menu for the napari-imagej widget.
 """
 from enum import Enum
 from pathlib import Path
-from threading import Thread
 from typing import Any, Dict, Optional, Union
 
 from jpype import JImplements, JOverride
@@ -16,7 +15,7 @@ from qtpy.QtGui import QIcon, QPixmap
 from qtpy.QtWidgets import QHBoxLayout, QMessageBox, QPushButton, QWidget
 
 from napari_imagej import settings
-from napari_imagej.java import ensure_jvm_started, ij, jc, log_debug
+from napari_imagej.java import ensure_jvm_started, ij, java_signals, jc, log_debug
 from napari_imagej.resources import resource_path
 from napari_imagej.utilities._module_utils import _get_layers_hack
 
@@ -247,24 +246,20 @@ class GUIButton(QPushButton):
         self.setIcon(icon)
 
         def post_setup():
-            ensure_jvm_started()
-            if ij():
-                self.setEnabled(True)
+            self.setEnabled(True)
 
-        Thread(target=post_setup).start()
+        java_signals.when_ij_ready(post_setup)
 
     def _setup_headful(self):
         self._set_icon(resource_path("imagej2-16x16-flat-disabled"))
         self.setToolTip("Display ImageJ2 GUI (loading)")
 
         def post_setup():
-            ensure_jvm_started()
-            if ij():
-                self._set_icon(resource_path("imagej2-16x16-flat"))
-                self.setEnabled(True)
-                self.setToolTip("Display ImageJ2 GUI")
+            self._set_icon(resource_path("imagej2-16x16-flat"))
+            self.setEnabled(True)
+            self.setToolTip("Display ImageJ2 GUI")
 
-        Thread(target=post_setup).start()
+        java_signals.when_ij_ready(post_setup)
 
     def _setup_headless(self):
         self._set_icon(resource_path("imagej2-16x16-flat-disabled"))

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -248,7 +248,8 @@ class GUIButton(QPushButton):
 
         def post_setup():
             ensure_jvm_started()
-            self.setEnabled(True)
+            if ij():
+                self.setEnabled(True)
 
         Thread(target=post_setup).start()
 
@@ -258,9 +259,10 @@ class GUIButton(QPushButton):
 
         def post_setup():
             ensure_jvm_started()
-            self._set_icon(resource_path("imagej2-16x16-flat"))
-            self.setEnabled(True)
-            self.setToolTip("Display ImageJ2 GUI")
+            if ij():
+                self._set_icon(resource_path("imagej2-16x16-flat"))
+                self.setEnabled(True)
+                self.setToolTip("Display ImageJ2 GUI")
 
         Thread(target=post_setup).start()
 

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -15,7 +15,7 @@ from qtpy.QtGui import QIcon, QPixmap
 from qtpy.QtWidgets import QHBoxLayout, QMessageBox, QPushButton, QWidget
 
 from napari_imagej import settings
-from napari_imagej.java import ij, init_ij, java_signals, jc, log_debug
+from napari_imagej.java import ij, java_signals, jc, log_debug
 from napari_imagej.resources import resource_path
 from napari_imagej.utilities._module_utils import _get_layers_hack
 
@@ -47,15 +47,18 @@ class NapariImageJMenu(QWidget):
 
     @property
     def gui(self) -> "jc.UserInterface":
-        """Convenience function for obtaining the default UserInterface"""
-        init_ij()
+        """
+        Convenience function for obtaining the default UserInterface
+
+        NB this field is a property so we can lazily evaluate the field.
+        This means we don't have to call ij() and start the JVM until we need it.
+        """
         return ij().ui().getDefaultUI()
 
     def _showUI(self):
         """
         NB: This must be its own function to prevent premature calling of ij()
         """
-        init_ij()
         # First time showing
         if not self.gui.isVisible():
             # First things first, show the GUI

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -15,7 +15,7 @@ from qtpy.QtGui import QIcon, QPixmap
 from qtpy.QtWidgets import QHBoxLayout, QMessageBox, QPushButton, QWidget
 
 from napari_imagej import settings
-from napari_imagej.java import ensure_jvm_started, ij, java_signals, jc, log_debug
+from napari_imagej.java import ij, init_ij, java_signals, jc, log_debug
 from napari_imagej.resources import resource_path
 from napari_imagej.utilities._module_utils import _get_layers_hack
 
@@ -48,14 +48,14 @@ class NapariImageJMenu(QWidget):
     @property
     def gui(self) -> "jc.UserInterface":
         """Convenience function for obtaining the default UserInterface"""
-        ensure_jvm_started()
+        init_ij()
         return ij().ui().getDefaultUI()
 
     def _showUI(self):
         """
         NB: This must be its own function to prevent premature calling of ij()
         """
-        ensure_jvm_started()
+        init_ij()
         # First time showing
         if not self.gui.isVisible():
             # First things first, show the GUI

--- a/src/napari_imagej/widgets/napari_imagej.py
+++ b/src/napari_imagej/widgets/napari_imagej.py
@@ -109,6 +109,9 @@ class NapariImageJWidget(QWidget):
         # Start constructing the ImageJ instance
         init_ij_async()
 
+    def wait_for_finalization(self):
+        self.ij_post_init_setup.wait()
+
     def _handle_error(self, exc: Exception):
         msg: QMessageBox = QMessageBox()
         msg.setText(str(exc))

--- a/src/napari_imagej/widgets/napari_imagej.py
+++ b/src/napari_imagej/widgets/napari_imagej.py
@@ -10,7 +10,7 @@ from qtpy.QtCore import QThread, Signal
 from qtpy.QtWidgets import QMessageBox, QTreeWidgetItem, QVBoxLayout, QWidget
 from scyjava import when_jvm_stops
 
-from napari_imagej.java import ij, init_ij, java_signals, jc
+from napari_imagej.java import ij, init_ij_async, java_signals, jc
 from napari_imagej.widgets.menu import NapariImageJMenu
 from napari_imagej.widgets.result_runner import ResultRunner
 from napari_imagej.widgets.result_tree import (
@@ -107,7 +107,7 @@ class NapariImageJWidget(QWidget):
         self.search.bar.setFocus()
 
         # Start constructing the ImageJ instance
-        init_ij()
+        init_ij_async()
 
     def _handle_error(self, exc: Exception):
         msg: QMessageBox = QMessageBox()

--- a/src/napari_imagej/widgets/napari_imagej.py
+++ b/src/napari_imagej/widgets/napari_imagej.py
@@ -94,7 +94,7 @@ class NapariImageJWidget(QWidget):
 
         # -- Final setup -- #
 
-        self.ij_post_init_setup: ImageJSetup = ImageJSetup(self)
+        self.ij_post_init_setup: WidgetFinalizer = WidgetFinalizer(self)
         java_signals.when_ij_ready(self.ij_post_init_setup.start)
 
         # Bind L key to search bar.
@@ -115,12 +115,29 @@ class NapariImageJWidget(QWidget):
         msg.exec()
 
 
-class ImageJSetup(QThread):
+class WidgetFinalizer(QThread):
+    """
+    QThread responsible for modifying NapariImageJWidget AFTER ImageJ is ready.
+    """
+
     def __init__(self, napari_imagej_widget: NapariImageJWidget):
         super().__init__()
         self.widget: NapariImageJWidget = napari_imagej_widget
 
     def run(self):
+        """
+        Finalizes components of napari_imagej_widget.
+
+        Functionality partitioned into functions by subwidget.
+        """
+        # Finalize the Results Tree
+        self._finalize_results_tree()
+
+    def _finalize_results_tree(self):
+        """
+        Finalizes the SearchResultTree starting state once ImageJ2 is ready.
+        """
+
         # Define our SearchListener
         @JImplements("org.scijava.search.SearchListener")
         class NapariImageJSearchListener:

--- a/src/napari_imagej/widgets/result_tree.py
+++ b/src/napari_imagej/widgets/result_tree.py
@@ -192,6 +192,8 @@ class SearchResultTree(QTreeWidget):
     def _init_producer(self):
         # First, wait for the JVM to start up
         ensure_jvm_started()
+        if not ij():
+            return
 
         # Then, define our SearchListener
         @JImplements("org.scijava.search.SearchListener")
@@ -219,6 +221,8 @@ class SearchResultTree(QTreeWidget):
     def _init_searchers(self):
         # First, wait for the JVM to start up
         ensure_jvm_started()
+        if not ij():
+            return
 
         # Add SearcherTreeItems for each Searcher
         searchers = ij().plugin().createInstancesOfType(jc.Searcher)

--- a/src/napari_imagej/widgets/searchbar.py
+++ b/src/napari_imagej/widgets/searchbar.py
@@ -8,7 +8,7 @@ are ready to accept queries.
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QHBoxLayout, QLineEdit, QWidget
 
-from napari_imagej.java import ensure_jvm_started, ij, java_signals
+from napari_imagej.java import ij, init_ij, java_signals
 
 
 class JVMEnabledSearchbar(QWidget):
@@ -54,7 +54,7 @@ class JLineEdit(QLineEdit):
 
     def enable(self):
         # Once the JVM is ready, allow editing
-        ensure_jvm_started()
+        init_ij()
         self.setText("")
         if ij():
             self.setEnabled(True)

--- a/src/napari_imagej/widgets/searchbar.py
+++ b/src/napari_imagej/widgets/searchbar.py
@@ -4,12 +4,11 @@ A QWidget used to provide input to SciJava Searchers.
 The bar is disabled until ImageJ is ready. This ensures the SciJava Searchers
 are ready to accept queries.
 """
-from threading import Thread
 
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QHBoxLayout, QLineEdit, QWidget
 
-from napari_imagej.java import ensure_jvm_started, ij
+from napari_imagej.java import ensure_jvm_started, ij, java_signals
 
 
 class JVMEnabledSearchbar(QWidget):
@@ -24,7 +23,8 @@ class JVMEnabledSearchbar(QWidget):
 
         # The main functionality is a search bar
         self.bar: JLineEdit = JLineEdit()
-        Thread(target=self.bar.enable).start()
+
+        java_signals.when_ij_ready(self.bar.enable)
 
         # Set GUI options
         self.setLayout(QHBoxLayout())

--- a/src/napari_imagej/widgets/searchbar.py
+++ b/src/napari_imagej/widgets/searchbar.py
@@ -9,7 +9,7 @@ from threading import Thread
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QHBoxLayout, QLineEdit, QWidget
 
-from napari_imagej.java import ensure_jvm_started
+from napari_imagej.java import ensure_jvm_started, ij
 
 
 class JVMEnabledSearchbar(QWidget):
@@ -56,4 +56,5 @@ class JLineEdit(QLineEdit):
         # Once the JVM is ready, allow editing
         ensure_jvm_started()
         self.setText("")
-        self.setEnabled(True)
+        if ij():
+            self.setEnabled(True)

--- a/src/napari_imagej/widgets/searchbar.py
+++ b/src/napari_imagej/widgets/searchbar.py
@@ -8,7 +8,7 @@ are ready to accept queries.
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QHBoxLayout, QLineEdit, QWidget
 
-from napari_imagej.java import ij, init_ij, java_signals
+from napari_imagej.java import java_signals
 
 
 class JVMEnabledSearchbar(QWidget):
@@ -24,7 +24,8 @@ class JVMEnabledSearchbar(QWidget):
         # The main functionality is a search bar
         self.bar: JLineEdit = JLineEdit()
 
-        java_signals.when_ij_ready(self.bar.enable)
+        java_signals.when_ij_ready(self.bar.finalize)
+        java_signals.when_initialization_fails(self.bar.on_error)
 
         # Set GUI options
         self.setLayout(QHBoxLayout())
@@ -52,9 +53,12 @@ class JLineEdit(QLineEdit):
         else:
             super().keyPressEvent(event)
 
-    def enable(self):
+    def finalize(self):
         # Once the JVM is ready, allow editing
-        init_ij()
         self.setText("")
-        if ij():
-            self.setEnabled(True)
+        self.setEnabled(True)
+
+    def on_error(self):
+        # If ImageJ errors
+        self.setText("Error: Invalid ImageJ2")
+        self.setEnabled(False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from napari import Viewer
 
 import napari_imagej
-from napari_imagej.java import ensure_jvm_started, ij_init
+from napari_imagej.java import ensure_jvm_started
 from napari_imagej.widgets.menu import NapariImageJMenu
 from napari_imagej.widgets.napari_imagej import NapariImageJWidget
 
@@ -48,7 +48,6 @@ def preserve_user_settings():
 @pytest.fixture(autouse=True)
 def launch_imagej():
     """Fixture ensuring that ImageJ is running before any tests run"""
-    ij_init()
     ensure_jvm_started()
     yield
 
@@ -72,6 +71,7 @@ def imagej_widget(viewer) -> Generator[NapariImageJWidget, None, None]:
     """Fixture providing an ImageJWidget"""
     # Create widget
     ij_widget: NapariImageJWidget = NapariImageJWidget(viewer)
+    ij_widget.ij_post_init_setup.wait()
 
     yield ij_widget
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from napari import Viewer
 
 import napari_imagej
-from napari_imagej.java import ensure_jvm_started
+from napari_imagej.java import init_ij
 from napari_imagej.widgets.menu import NapariImageJMenu
 from napari_imagej.widgets.napari_imagej import NapariImageJWidget
 
@@ -48,7 +48,7 @@ def preserve_user_settings():
 @pytest.fixture(autouse=True)
 def launch_imagej():
     """Fixture ensuring that ImageJ is running before any tests run"""
-    ensure_jvm_started()
+    init_ij()
     yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def imagej_widget(viewer) -> Generator[NapariImageJWidget, None, None]:
     """Fixture providing an ImageJWidget"""
     # Create widget
     ij_widget: NapariImageJWidget = NapariImageJWidget(viewer)
-    ij_widget.ij_post_init_setup.wait()
+    ij_widget.wait_for_finalization()
 
     yield ij_widget
 

--- a/tests/widgets/test_napari_imagej.py
+++ b/tests/widgets/test_napari_imagej.py
@@ -160,3 +160,12 @@ def test_imagej_search_tree_disable(ij, imagej_widget: NapariImageJWidget, asser
             searcher_item._searcher
         )
     )
+
+
+def test_widget_finalization(ij, imagej_widget: NapariImageJWidget, asserter):
+    # Ensure that we have the handle on a non-null SearchOperation
+    assert imagej_widget.result_tree._searchOperation is not None
+
+    # Ensure that all Searchers are represented in the tree with a top level item
+    numSearchers = len(ij.plugin().getPluginsOfType(jc.Searcher))
+    asserter(lambda: imagej_widget.result_tree.topLevelItemCount() == numSearchers)

--- a/tests/widgets/test_napari_imagej.py
+++ b/tests/widgets/test_napari_imagej.py
@@ -42,9 +42,8 @@ def _run_buttons(imagej_widget: NapariImageJWidget):
     return imagej_widget.result_runner.button_pane.findChildren(QPushButton)
 
 
-def _ensure_searchers_available(imagej_widget, asserter):
+def _ensure_searchers_available(imagej_widget: NapariImageJWidget, asserter):
     tree = imagej_widget.result_tree
-    tree.wait_for_setup()
     # Find the ModuleSearcher
     numSearchers = len(ij().plugin().getPluginsOfType(jc.Searcher))
     try:

--- a/tests/widgets/test_result_tree.py
+++ b/tests/widgets/test_result_tree.py
@@ -10,7 +10,7 @@ from napari_imagej.widgets.result_tree import (
     SearchResultTree,
     SearchResultTreeItem,
 )
-from tests.utils import DummySearcher, DummySearchEvent, DummySearchResult, jc
+from tests.utils import DummySearcher, DummySearchEvent, DummySearchResult
 from tests.widgets.widget_utils import _populate_tree
 
 
@@ -24,20 +24,6 @@ def fixed_tree(ij, asserter):
     """Creates a "fake" ResultsTree with deterministic results"""
     # Create a default SearchResultTree
     tree = SearchResultTree()
-    tree.wait_for_setup()
-    # Waits until all Searchers available
-    scijava_searchers = ij.plugin().createInstancesOfType(jc.Searcher)
-    try:
-        asserter(lambda: tree.topLevelItemCount() == len(scijava_searchers))
-    except Exception:
-        # HACK: Sometimes (especially on CI), not all Searchers make it into
-        # the tree.
-        # For our purposes of removing those items, though, we don't care how
-        # many make it in. All that matters is that no more will be added.
-        # So, if we timeout, we assume no more will be added, and carry on.
-        pass
-    # Remove all SciJava Searchers, use our own ones instead
-    tree.invisibleRootItem().takeChildren()
     _populate_tree(tree, asserter)
 
     return tree

--- a/tests/widgets/test_searchbar.py
+++ b/tests/widgets/test_searchbar.py
@@ -3,13 +3,12 @@ A module testing napari_imagej.widgets.searchbar
 """
 from qtpy.QtWidgets import QHBoxLayout, QLineEdit
 
-from napari_imagej.widgets.napari_imagej import NapariImageJWidget
 from napari_imagej.widgets.searchbar import JLineEdit, JVMEnabledSearchbar
 
 
-def test_searchbar_widget_layout(imagej_widget: NapariImageJWidget):
+def test_searchbar_widget_layout():
     """Tests the number and expected order of search widget children"""
-    searchbar: JVMEnabledSearchbar = imagej_widget.findChild(JVMEnabledSearchbar)
+    searchbar: JVMEnabledSearchbar = JVMEnabledSearchbar()
     subwidgets = searchbar.children()
     assert len(subwidgets) == 2
     assert isinstance(subwidgets[0], QHBoxLayout)


### PR DESCRIPTION
This PR allows us to enforce minimum versions for Java components.

When one or more java components do not satisfy the minimums, napari-imagej will:
* Display a popup stating which components are too old.
* Prompt the user to ensure their ImageJ endpoint is correct
* Disable (actually, blocks the enabling of) ImageJ functionality.

Thanks @ctrueden for the feedback.

EDIT: Unfortunately, I also rewrote all `Thread`s as `QThreads`. It's a good change, but I didn't mean to do it here. Oh well...