### PR TITLE
Add support for imglib2-algorithm shapes

### DIFF
--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -495,6 +495,44 @@ class JavaClasses(object):
     def RealType(self):
         return "net.imglib2.type.numeric.RealType"
 
+    # ImgLib2-algorithm Types
+
+    @blocking_import
+    def CenteredRectangleShape(self):
+        return "net.imglib2.algorithm.neighborhood.CenteredRectangleShape"
+
+    @blocking_import
+    def DiamondShape(self):
+        return "net.imglib2.algorithm.neighborhood.DiamondShape"
+
+    @blocking_import
+    def DiamondTipsShape(self):
+        return "net.imglib2.algorithm.neighborhood.DiamondTipsShape"
+
+    @blocking_import
+    def HorizontalLineShape(self):
+        return "net.imglib2.algorithm.neighborhood.HorizontalLineShape"
+
+    @blocking_import
+    def HyperSphereShape(self):
+        return "net.imglib2.algorithm.neighborhood.HyperSphereShape"
+
+    @blocking_import
+    def PairOfPointsShape(self):
+        return "net.imglib2.algorithm.neighborhood.PairOfPointsShape"
+
+    @blocking_import
+    def PeriodicLineShape(self):
+        return "net.imglib2.algorithm.neighborhood.PeriodicLineShape"
+
+    @blocking_import
+    def RectangleShape(self):
+        return "net.imglib2.algorithm.neighborhood.RectangleShape"
+
+    @blocking_import
+    def Shape(self):
+        return "net.imglib2.algorithm.neighborhood.Shape"
+
     # ImgLib2-roi Types
 
     @blocking_import

--- a/src/napari_imagej/types/type_conversions.py
+++ b/src/napari_imagej/types/type_conversions.py
@@ -96,8 +96,18 @@ def enum_converter(item: "jc.ModuleItem"):
 
 @module_item_converter()
 def widget_enabled_java_types(item: "jc.ModuleItem"):
+    """
+    Checks to see if this JAVA type is fully supported through magicgui widgets.
+    This is sometimes done to expose object creation/usage when there ISN'T
+    a good Python equivalent.
+    """
     if item.isInput() and not item.isOutput():
         if item.getType() in widget_supported_java_types():
+            # TODO: NB: Ideally, we'd return item.getType() here.
+            # Unfortunately, though, that doesn't work, and I can't figure out why
+            # due to https://github.com/imagej/napari-imagej/issues/7
+            # For that reason, we return the Python type JObject instead.
+            # While this return isn't WRONG, it could be MORE correct.
             return JObject
 
 

--- a/src/napari_imagej/types/type_conversions.py
+++ b/src/napari_imagej/types/type_conversions.py
@@ -18,12 +18,14 @@ Notable functions included in the module:
 """
 from typing import Callable, List, Optional, Tuple, Type
 
+from jpype import JObject
 from scyjava import Priority
 
 from napari_imagej.java import ij, jc
 from napari_imagej.types.enum_likes import enum_like
 from napari_imagej.types.enums import py_enum_for
 from napari_imagej.types.mappings import ptypes
+from napari_imagej.widgets.parameter_widgets import widget_supported_java_types
 
 # List of Module Item Converters, along with their priority
 _MODULE_ITEM_CONVERTERS: List[Tuple[Callable, int]] = []
@@ -90,6 +92,13 @@ def enum_converter(item: "jc.ModuleItem"):
     if not isinstance(t, jc.Class):
         t = t.class_
     return _optional_of(py_enum_for(t), item)
+
+
+@module_item_converter()
+def widget_enabled_java_types(item: "jc.ModuleItem"):
+    if item.isInput() and not item.isOutput():
+        if item.getType() in widget_supported_java_types():
+            return JObject
 
 
 def _checkerUsingFunc(

--- a/src/napari_imagej/types/widget_mappings.py
+++ b/src/napari_imagej/types/widget_mappings.py
@@ -12,6 +12,7 @@ from napari.layers import Image
 
 from napari_imagej.java import jc
 from napari_imagej.widgets.parameter_widgets import (
+    ShapeWidget,
     file_widget_for,
     numeric_type_widget_for,
 )
@@ -82,6 +83,15 @@ def _mutable_output_preference(
             or str(type_hint) == "typing.Optional[ForwardRef('napari.layers.Image')]"
         ):
             return "napari_imagej.widgets.parameter_widgets.MutableOutputWidget"
+
+
+@_widget_preference
+def _shape_preference(
+    item: "jc.ModuleItem", type_hint: Union[type, str]
+) -> Optional[Union[type, str]]:
+    if item.isInput() and not item.isOutput():
+        if item.getType() == jc.Shape:
+            return ShapeWidget
 
 
 # The definitive mapping of scijava widget styles to magicgui widget types

--- a/src/napari_imagej/widgets/parameter_widgets.py
+++ b/src/napari_imagej/widgets/parameter_widgets.py
@@ -401,7 +401,7 @@ class ShapeWidget(Container):
                 "Centered Rectangle",
                 jc.CenteredRectangleShape,
                 [
-                    ShapeParam("span", ListEdit, JArray(JInt)),
+                    ShapeParam("span", ListEdit, JArray(JInt), default=[1, 1]),
                     ShapeParam("skipCenter", CheckBox),
                 ],
             ),
@@ -409,22 +409,22 @@ class ShapeWidget(Container):
                 "Diamond",
                 jc.DiamondShape,
                 [
-                    ShapeParam("radius", SpinBox),
+                    ShapeParam("radius", SpinBox, default=1),
                 ],
             ),
             ShapeData(
                 "Diamond Tips",
                 jc.DiamondTipsShape,
                 [
-                    ShapeParam("radius", SpinBox),
+                    ShapeParam("radius", SpinBox, default=1),
                 ],
             ),
             ShapeData(
                 "Horizontal Line",
                 jc.HorizontalLineShape,
                 [
-                    ShapeParam("span", SpinBox, JLong),
-                    ShapeParam("dimension", SpinBox, JInt),
+                    ShapeParam("span", SpinBox, JLong, default=1),
+                    ShapeParam("dimension", SpinBox, JInt, default=0),
                     ShapeParam("skip center", CheckBox),
                 ],
             ),
@@ -432,29 +432,29 @@ class ShapeWidget(Container):
                 "Hypersphere",
                 jc.HyperSphereShape,
                 [
-                    ShapeParam("radius", SpinBox, JLong),
+                    ShapeParam("radius", SpinBox, JLong, default=1),
                 ],
             ),
             ShapeData(
                 "Pair of Points",
                 jc.PairOfPointsShape,
                 [
-                    ShapeParam("offset", ListEdit, JArray(JLong)),
+                    ShapeParam("offset", ListEdit, JArray(JLong), default=[1, 1]),
                 ],
             ),
             ShapeData(
                 "Periodic Line",
                 jc.PeriodicLineShape,
                 [
-                    ShapeParam("span", SpinBox, JLong),
-                    ShapeParam("increments", ListEdit, JArray(JInt)),
+                    ShapeParam("span", SpinBox, JLong, default=1),
+                    ShapeParam("increments", ListEdit, JArray(JInt), default=[1, 1]),
                 ],
             ),
             ShapeData(
                 "Rectangle",
                 jc.RectangleShape,
                 [
-                    ShapeParam("span", SpinBox, JInt),
+                    ShapeParam("span", SpinBox, JInt, default=1),
                     ShapeParam("skip center", CheckBox),
                 ],
             ),

--- a/tests/types/test_type_conversions.py
+++ b/tests/types/test_type_conversions.py
@@ -4,6 +4,7 @@ A module testing napari_imagej.types.type_conversions
 from typing import List
 
 import pytest
+from jpype import JObject
 
 from napari_imagej.types.enum_likes import OutOfBoundsFactory
 from napari_imagej.types.mappings import ptypes
@@ -95,3 +96,8 @@ def test_python_type_of_enum_like_IO():
 def test_enum():
     p_type = _module_utils.python_type_of(DummyModuleItem(jtype=jc.ItemIO))
     assert p_type.__name__ == "ItemIO"
+
+
+def test_shape():
+    p_type = _module_utils.python_type_of(DummyModuleItem(jtype=jc.Shape))
+    assert p_type == JObject

--- a/tests/types/test_widget_mappings.py
+++ b/tests/types/test_widget_mappings.py
@@ -26,6 +26,7 @@ from napari_imagej.widgets.parameter_widgets import (
     MutableOutputWidget,
     OpenFileWidget,
     SaveFileWidget,
+    ShapeWidget,
 )
 from tests.utils import DummyModuleItem, jc
 
@@ -126,3 +127,9 @@ def test_file_widgets():
     item.setWidgetStyle(jc.FileWidget.DIRECTORY_STYLE)
     type_hint = python_type_of(item)
     assert preferred_widget_for(item, type_hint) == DirectoryWidget
+
+
+def test_shape_widget():
+    item = DummyModuleItem(jtype=jc.Shape)
+    type_hint = python_type_of(item)
+    assert preferred_widget_for(item, type_hint) == ShapeWidget

--- a/tests/widgets/test_parameter_widgets.py
+++ b/tests/widgets/test_parameter_widgets.py
@@ -7,7 +7,14 @@ import napari
 import numpy as np
 import pytest
 from magicgui.types import FileDialogMode
-from magicgui.widgets import ComboBox, PushButton
+from magicgui.widgets import (
+    CheckBox,
+    ComboBox,
+    Container,
+    ListEdit,
+    PushButton,
+    SpinBox,
+)
 from napari import current_viewer
 from napari.layers import Image
 
@@ -16,6 +23,7 @@ from napari_imagej.widgets.parameter_widgets import (
     MutableOutputWidget,
     OpenFileWidget,
     SaveFileWidget,
+    ShapeWidget,
     numeric_type_widget_for,
 )
 from tests.utils import jc
@@ -200,3 +208,150 @@ def test_open_file_widget():
 def test_directory_file_widget():
     widget = DirectoryWidget()
     assert widget.mode == FileDialogMode.EXISTING_DIRECTORY
+
+
+def test_shape_widget_regression():
+    widget = ShapeWidget()
+    # Assert widget type
+    assert isinstance(widget, Container)
+    # Assert that widget contains a dropdown and shape options
+    assert len(widget) == 2
+    assert isinstance(widget[0], ComboBox)
+    assert isinstance(widget[1], Container)
+    # Assert starting value
+    assert widget[0].value == "Centered Rectangle"
+
+
+def test_shape_widget_centered_rectangle():
+    # Choose a Centered Rectangle
+    widget = ShapeWidget()
+    widget[0].value = "Centered Rectangle"
+    # Assert parameter option widgets
+    assert len(widget.shape_options) == 2
+    assert isinstance(widget.shape_options[0], ListEdit)
+    assert isinstance(widget.shape_options[1], CheckBox)
+    # Assert starting values
+    assert widget.shape_options[0].value == [1, 1]
+    assert not widget.shape_options[1].value
+    # Assert the value returned is a CenteredRectangleShape
+    value = widget.value
+    assert isinstance(value, jc.CenteredRectangleShape)
+    assert np.array_equal(value.getSpan(), np.ones((2)))
+    assert not value.isSkippingCenter()
+
+
+def test_shape_widget_diamond():
+    # Choose a Diamond
+    widget = ShapeWidget()
+    widget[0].value = "Diamond"
+    # Assert parameter option widgets
+    assert len(widget.shape_options) == 1
+    assert isinstance(widget.shape_options[0], SpinBox)
+    # Assert starting values
+    assert widget.shape_options[0].value == 1
+    # Assert the value returned is a DiamondShape
+    value = widget.value
+    assert isinstance(value, jc.DiamondShape)
+    assert value.getRadius() == 1
+
+
+def test_shape_widget_diamond_tips():
+    # Choose a DiamondTips
+    widget = ShapeWidget()
+    widget[0].value = "Diamond Tips"
+    # Assert parameter option widgets
+    assert len(widget.shape_options) == 1
+    assert isinstance(widget.shape_options[0], SpinBox)
+    # Assert starting values
+    assert widget.shape_options[0].value == 1
+    # Assert the value returned is a DiamondTipsShape
+    value = widget.value
+    assert isinstance(value, jc.DiamondTipsShape)
+    assert value.getRadius() == 1
+
+
+def test_shape_widget_horizontal_line():
+    # Choose a Horizontal Line
+    widget = ShapeWidget()
+    widget[0].value = "Horizontal Line"
+    # Assert parameter option widgets
+    assert len(widget.shape_options) == 3
+    assert isinstance(widget.shape_options[0], SpinBox)
+    assert isinstance(widget.shape_options[1], SpinBox)
+    assert isinstance(widget.shape_options[2], CheckBox)
+    # Assert starting values
+    assert widget.shape_options[0].value == 1
+    assert widget.shape_options[1].value == 0
+    assert not widget.shape_options[2].value
+    # Assert the value returned is a HorizontalLineShape
+    value = widget.value
+    assert isinstance(value, jc.HorizontalLineShape)
+    assert value.getSpan() == 1
+    assert value.getLineDimension() == 0
+    assert not value.isSkippingCenter()
+
+
+def test_shape_widget_hypersphere():
+    # Choose a Hypersphere
+    widget = ShapeWidget()
+    widget[0].value = "Hypersphere"
+    # Assert parameter option widgets
+    assert len(widget.shape_options) == 1
+    assert isinstance(widget.shape_options[0], SpinBox)
+    # Assert starting values
+    assert widget.shape_options[0].value == 1
+    # Assert the value returned is a HyperSphereShape
+    value = widget.value
+    assert isinstance(value, jc.HyperSphereShape)
+    assert value.getRadius() == 1
+
+
+def test_shape_widget_pair_of_points():
+    # Choose a Pair of Points
+    widget = ShapeWidget()
+    widget[0].value = "Pair of Points"
+    # Assert parameter option widgets
+    assert len(widget.shape_options) == 1
+    assert isinstance(widget.shape_options[0], ListEdit)
+    # Assert starting values
+    assert widget.shape_options[0].value == [1, 1]
+    # Assert the value returned is a PairofPointsShape
+    value = widget.value
+    assert isinstance(value, jc.PairOfPointsShape)
+    assert np.array_equal(value.getOffset(), np.ones((2)))
+
+
+def test_shape_widget_periodic_line():
+    # Choose a Periodic Line
+    widget = ShapeWidget()
+    widget[0].value = "Periodic Line"
+    # Assert parameter option widgets
+    assert len(widget.shape_options) == 2
+    assert isinstance(widget.shape_options[0], SpinBox)
+    assert isinstance(widget.shape_options[1], ListEdit)
+    # Assert starting values
+    assert widget.shape_options[0].value == 1
+    assert widget.shape_options[1].value == [1, 1]
+    # Assert the value returned is a PeriodicLineShape
+    value = widget.value
+    assert isinstance(value, jc.PeriodicLineShape)
+    assert value.getSpan() == 1
+    assert np.array_equal(value.getIncrements(), np.ones((2)))
+
+
+def test_shape_widget_rectangle():
+    # Choose a Rectangle
+    widget = ShapeWidget()
+    widget[0].value = "Rectangle"
+    # Assert parameter option widgets
+    assert len(widget.shape_options) == 2
+    assert isinstance(widget.shape_options[0], SpinBox)
+    assert isinstance(widget.shape_options[1], CheckBox)
+    # Assert starting values
+    assert widget.shape_options[0].value == 1
+    assert not widget.shape_options[1].value
+    # Assert the value returned is a RectangleShape
+    value = widget.value
+    assert isinstance(value, jc.RectangleShape)
+    assert value.getSpan() == 1
+    assert not value.isSkippingCenter()


### PR DESCRIPTION
This PR adds a parameter widget used to construct imglib2-algorithm [`Shape`](https://github.com/imglib/imglib2-algorithm/blob/b6c9569dedd76f503f2d10ac151943028223e8f9/src/main/java/net/imglib2/algorithm/neighborhood/Shape.java#L54)s. All current implementations are hardcoded as options, with the choice selected through a dropdown menu.