### PR TITLE
Add minimum scijava-search version

### DIFF
--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -211,8 +211,9 @@ class ImageJInitializer(QThread):
         # a class to query
         component_requirements: List[Tuple[JClass, str, str]] = [
             (jc.Dataset, "net.imagej:imagej-common", "2.0.2"),
-            (jc.Module, "org.scijava:scijava-common", "2.89.0"),
             (jc.OpInfo, "net.imagej:imagej-ops", "0.48.0"),
+            (jc.Module, "org.scijava:scijava-common", "2.89.0"),
+            (jc.Searcher, "org.scijava:scijava-search", "2.0.0"),
         ]
 
         # Find version that violate the minimum


### PR DESCRIPTION
This change ensures scijava/scijava-search#27 is included, allowing control to return to the user after when the GUI is closed.

Requires the merge of scijava/scijava-search#27 and a subsequent release.