### PR TITLE
Bump python versioning to [3.8, 3.11]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,16 +23,16 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.10']
+        python-version: ['3.8', '3.11']
 
-        # Breaks due to https://github.com/jpype-project/jpype/issues/1009
-        # Should be included once the fix is released
-        exclude:
-          - platform: windows-latest
-            python-version: "3.10"
-        include:
-          - platform: windows-latest
-            python-version: "3.9"
+        # # Breaks due to https://github.com/jpype-project/jpype/issues/1009
+        # # Should be included once the fix is released
+        # exclude:
+        #   - platform: windows-latest
+        #     python-version: "3.10"
+        # include:
+        #   - platform: windows-latest
+        #     python-version: "3.9"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,10 @@ jobs:
         uses: isort/isort-action@master
         with:
           configuration: --check-only
+      - name: Validate pyproject.toml
+        run: |
+          python -m pip install validate-pyproject[all]
+          python -m validate_pyproject pyproject.toml
 
   test-ij2:
     name: Test pure IJ2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,22 +73,28 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+      # This step ensures that everything is installed
+      - name: Install code cleaning components
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]'
 
       - name: Lint code
         uses: psf/black@stable
 
       - name: Flake code
         run: |
-          python -m pip install flake8
           python -m flake8 src tests
 
       - name: Check import ordering
         uses: isort/isort-action@master
         with:
           configuration: --check-only
+
       - name: Validate pyproject.toml
         run: |
-          python -m pip install validate-pyproject[all]
           python -m validate_pyproject pyproject.toml
 
   test-ij2:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,16 +23,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.11']
-
-        # # Breaks due to https://github.com/jpype-project/jpype/issues/1009
-        # # Should be included once the fix is released
-        # exclude:
-        #   - platform: windows-latest
-        #     python-version: "3.10"
-        # include:
-        #   - platform: windows-latest
-        #     python-version: "3.9"
+        python-version: ['3.8', '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-typing-imports==1.7.0]
+        additional_dependencies: [Flake8-pyproject, flake8-typing-imports==1.7.0]
   # Next, sort imports
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -46,4 +46,5 @@ dependencies:
   # Project from source
   - pip
   - pip:
+    - validate-pyproject[all]
     - -e '.'

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -35,6 +35,7 @@ dependencies:
   - black
   - build
   - flake8
+  - flake8-typing-imports
   - isort
   - pre-commit
   - pyqt5-sip
@@ -46,5 +47,6 @@ dependencies:
   # Project from source
   - pip
   - pip:
+    - flake8-pyproject
     - validate-pyproject[all]
     - -e '.'

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -19,6 +19,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - python >= 3.8
   # Project dependencies
   - confuse
   - jpype1 >= 1.4.1
@@ -27,7 +28,6 @@ dependencies:
   - napari
   - numpy
   - openjdk=8
-  - python >= 3.8
   - pyimagej >= 1.3.0
   - scyjava >= 1.8.1
   # Developer tools

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -21,10 +21,12 @@ channels:
 dependencies:
   # Project dependencies
   - confuse
+  - jpype1 >= 1.4.1
   - labeling >= 0.1.12
   - magicgui >= 0.5.1
   - napari
   - openjdk=8
+  - python >= 3.8
   - pyimagej >= 1.3.0
   - scyjava >= 1.8.1
   # Test dependencies

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -25,12 +25,11 @@ dependencies:
   - labeling >= 0.1.12
   - magicgui >= 0.5.1
   - napari
+  - numpy
   - openjdk=8
   - python >= 3.8
   - pyimagej >= 1.3.0
   - scyjava >= 1.8.1
-  # Test dependencies
-  - numpy
   # Developer tools
   - autopep8
   - black

--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - python >= 3.8
   # Project depenencies
   - confuse
   - jpype1 >= 1.4.1
@@ -27,7 +28,6 @@ dependencies:
   - napari
   - numpy
   - openjdk=8
-  - python >= 3.8
   - pyimagej >= 1.3.0
   - scyjava >= 1.8.1
   # Project from source

--- a/environment.yml
+++ b/environment.yml
@@ -33,4 +33,5 @@ dependencies:
   # Project from source
   - pip
   - pip:
+    - validate-pyproject[all]
     - '.'

--- a/environment.yml
+++ b/environment.yml
@@ -21,11 +21,13 @@ channels:
 dependencies:
   # Project depenencies
   - confuse
+  - jpype1 >= 1.4.1
   - labeling >= 0.1.12
   - magicgui >= 0.5.1
   - napari
   - numpy
   - openjdk=8
+  - python >= 3.8
   - pyimagej >= 1.3.0
   - scyjava >= 1.8.1
   # Project from source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "pytest-env",
     "pytest-qt",
     "qtpy",
+    "validate-pyproject[all]",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,83 @@
 [build-system]
-# Setuptools version constraint ensures PEP 517 compatibility
-requires = [
-    "setuptools >= 45",
-    "wheel",
-]
+requires = [ "setuptools>=61.2" ]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "napari-imagej"
+version = "0.1.0.dev0"
+description = "ImageJ functionality from napari"
+readme = "README.md"
+license = {text = "BSD-3-Clause"}
+authors = [{name = "ImageJ2 developers", email = "ctrueden@wisc.edu"}]
+keywords = ["java", "imagej", "imagej2", "fiji", "napari"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Framework :: napari",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+    "License :: OSI Approved :: BSD License",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Image Processing",
+    "Topic :: Scientific/Engineering :: Visualization",
+    "Topic :: Software Development :: Libraries :: Java Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+# NB: Keep this in sync with environment.yml AND dev-environment.yml!
+requires-python = ">=3.8"
+dependencies = [
+    "confuse",
+    "jpype1 >= 1.4.1",
+    "labeling >= 0.1.12",
+    "magicgui >= 0.5.1",
+    "napari",
+    "numpy",
+    "pyimagej >= 1.3.0",
+    "scyjava >= 1.8.1",
+]
+
+[project.optional-dependencies]
+# NB: Keep this in sync with dev-environment.yml!
+# Development tools
+dev = [
+    "autopep8",
+    "black",
+    "build",
+    "flake8",
+    "isort",
+    "pre-commit",
+    "pyqt5",
+    "pytest",
+    "pytest-cov",
+    "pytest-env",
+    "pytest-qt",
+    "qtpy",
+]
+
+[project.urls]
+homepage = "https://github.com/imagej/napari-imagej"
+documentation = "https://github.com/imagej/napari-imagej#README.md"
+source = "https://github.com/imagej/napari-imagej"
+download = "https://pypi.org/project/napari-imagej/"
+tracker = "https://github.com/imagej/napari-imagej/issues"
+
+[project.entry-points."napari.manifest"]
+napari-imagej = "napari_imagej:napari.yml"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dev = [
     "black",
     "build",
     "flake8",
+    "flake8-pyproject",
+    "flake8-typing-imports",
     "isort",
     "pre-commit",
     "pyqt5",
@@ -79,6 +81,14 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+# Thanks to Flake8-pyproject, we can configure flake8 here!
+[tool.flake8]
+exclude = ["bin", "build", "docs", "dist"]
+extend-ignore = ["E203"]
+# See https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
+max-line-length = 88
+min_python_version = "3.8"
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,81 +1,9 @@
-[metadata]
-name = napari-imagej
-version = 0.1.0.dev0
-author = ImageJ2 developers
-author_email = ctrueden@wisc.edu
-url = https://github.com/imagej/napari-imagej
-license = BSD-3-Clause
-description = Use ImageJ functionality from napari
-long_description = file: README.md
-long_description_content_type = text/markdown
-include_package_data = True
-classifiers =
-    Development Status :: 2 - Pre-Alpha
-    Intended Audience :: Developers
-    Framework :: napari
-    Topic :: Software Development :: Testing
-    Programming Language :: Python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Operating System :: MacOS
-    Operating System :: Microsoft :: Windows
-    Operating System :: Unix
-    License :: OSI Approved :: BSD License
-project_urls =
-    Bug Tracker = https://github.com/imagej/napari-imagej/issues
-    Documentation = https://github.com/imagej/napari-imagej#README.md
-    Source Code = https://github.com/imagej/napari-imagej
-    User Support = https://github.com/imagej/napari-imagej/issues
-
-[options]
-packages = find:
-python_requires = >=3.8
-package_dir =
-    =src
-
-# add your package requirements here
-install_requires =
-    confuse
-    labeling >= 0.1.12
-    # TODO: remove upon next napari release
-    imageio != 2.22.1
-    napari
-    numpy
-    magicgui >= 0.5.1
-    pyimagej >= 1.3.0
-    scyjava >= 1.8.1
-
-[options.packages.find]
-where = src
-
-[options.package_data]
-napari-imagej = napari.yml
-
-[options.entry_points] 
-napari.manifest = 
-    napari-imagej = napari_imagej:napari.yml
-
-[options.extras_require]
-
-# Ensure any changes to this list are also added to environment-test.yml!
-dev =
-    autopep8
-    black
-    build
-    flake8
-    isort
-    pyqt5
-    pytest
-    pytest-cov
-    pytest-env
-    pytest-qt
-    qtpy
-    numpy
-
 [flake8]
 # See https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
 max-line-length = 88
+exclude =
+    bin
+    build
+    docs
+    dist
 extend-ignore = E203

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,0 @@
-[flake8]
-# See https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
-max-line-length = 88
-exclude =
-    bin
-    build
-    docs
-    dist
-extend-ignore = E203

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,10 @@ classifiers =
     Topic :: Software Development :: Testing
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
     Operating System :: Unix
@@ -31,7 +32,7 @@ project_urls =
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 package_dir =
     =src
 


### PR DESCRIPTION
This PR removes support for Python 3.7, as napari no longer supports it, and begins testing Python 3.11, as it has been released!

Note that the validity of the build process was checked as follows:
```
git checkout 18a6bba;
python -m build;
cd dist;
tar xzvf napari-imagej-0.1.0.dev0.tar.gz;
mv napari-imagej-0.1.0.dev0 ../old;
cd ..;
git checkout 147-bump-minimum-python-version-to-38;
python -m build;
cd dist;
tar xzvf napari-imagej-0.1.0.dev0.tar.gz;
mv napari-imagej-0.1.0.dev0 ../new;
cd ..;
diff old new;
rm -rf old new;
```