### PR TITLE
Add validation for ij_dir_or_endpoint setting

### DIFF
--- a/src/napari_imagej/__init__.py
+++ b/src/napari_imagej/__init__.py
@@ -55,6 +55,20 @@ class _NapariImageJSettings(confuse.Configuration):
         :param value: The value assigned to a particular setting
         :param strict: If true, raise an Error. If false, assign a reasonable default.
         """
+        if setting == "imagej_directory_or_endpoint":
+            # Ensure a valid endpoint/directory
+            if value in ["", None]:
+                if strict:  # Report the failure
+                    raise ValueError(
+                        "Please specify an imagej directory or endpoint in "
+                        "your configuration."
+                    )
+                else:  # Assign a reasonable default
+                    log_debug(
+                        "No provided imagej directory or endpoint. Setting endpoint "
+                        "to net.imagej:imagej"
+                    )
+                    self["imagej_directory_or_endpoint"] = "net.imagej:imagej"
         if setting == "jvm_mode":
             # Ensure a valid jvm mode choice
             self["jvm_mode"].as_choice(["interactive", "headless"])

--- a/src/napari_imagej/__init__.py
+++ b/src/napari_imagej/__init__.py
@@ -60,8 +60,15 @@ class _NapariImageJSettings(confuse.Configuration):
             if value in ["", None]:
                 if strict:  # Report the failure
                     raise ValueError(
-                        "Please specify an imagej directory or endpoint in "
-                        "your configuration."
+                        "The imagej directory or endpoint cannot be blank! "
+                        "<p><font face='courier'>net.imagej:imagej</font> "
+                        "is the default option."
+                        "<p>Visit "
+                        '<a href="https://pyimagej.readthedocs.io/en/latest/'
+                        'api.html#initialization">this site</a> '
+                        "and check the "
+                        "<font face='courier'>ij_dir_or_version_or_endpoint</font> "
+                        "parameter for more options."
                     )
                 else:  # Assign a reasonable default
                     log_debug(
@@ -76,7 +83,7 @@ class _NapariImageJSettings(confuse.Configuration):
             if value == "interactive" and sys.platform == "darwin":
                 if strict:  # Report the failure
                     raise ValueError(
-                        "ImageJ2 must be run headlessly on MacOS. Visit "
+                        "ImageJ2 must be run headlessly on MacOS. <p>Visit "
                         '<a href="https://pyimagej.readthedocs.io/en/latest/'
                         'Initialization.html#interactive-mode">this site</a> '
                         "for more information."

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -374,7 +374,11 @@ class SettingsButton(QPushButton):
         except Exception as exc:
             # New value incompatible; report it to the user
             RichTextPopup(
-                rich_message=f"<b>Ignoring selection for setting {setting}:</b> {exc}",
+                rich_message=(
+                    "<b>Ignoring selection for setting <font face='courier'>"
+                    f"{setting}"
+                    f"</font>:</b><p>{exc}"
+                ),
                 exec=True,
             )
             return False

--- a/tests/widgets/test_menu.py
+++ b/tests/widgets/test_menu.py
@@ -340,6 +340,54 @@ def test_settings_change(popup_handler, gui_widget: NapariImageJMenu):
         assert yaml.safe_load(stream)[key] == new_value
 
 
+def test_empty_ij_dir_str_prevention(popup_handler, gui_widget: NapariImageJMenu):
+    """Change ij_dir_or_endpoint to an empty string, assert that it cannot be done"""
+    button: SettingsButton = gui_widget.settings_button
+
+    # REQUEST_VALUES MOCK
+    oldfunc = menu.request_values
+
+    assert settings["imagej_directory_or_endpoint"].get() == "net.imagej:imagej"
+
+    def newfunc(values={}, title="", **kwargs):
+        results = {}
+        # Solve each parameter
+        for name, options in values.items():
+            if name == "imagej_directory_or_endpoint":
+                results[name] = ""
+                continue
+            elif "value" in options:
+                results[name] = options["value"]
+                continue
+
+            # Otherwise, we don't know how to solve that parameter
+            raise NotImplementedError()
+        return results
+
+    menu.request_values = newfunc
+
+    # Handle the popup from button._update_settings
+    expected_text = (
+        "<b>Ignoring selection for setting "
+        "<font face='courier'>imagej_directory_or_endpoint</font>:</b><p>"
+        "The imagej directory or endpoint cannot be blank! "
+        "<p><font face='courier'>net.imagej:imagej</font> "
+        "is the default option."
+        "<p>Visit "
+        '<a href="https://pyimagej.readthedocs.io/en/latest/'
+        'api.html#initialization">this site</a> '
+        "and check the "
+        "<font face='courier'>ij_dir_or_version_or_endpoint</font> "
+        "parameter for more options."
+    )
+    popup_handler(expected_text, button._update_settings)
+
+    menu.request_values = oldfunc
+
+    # Assert no change in the settings
+    assert settings["imagej_directory_or_endpoint"].get() == "net.imagej:imagej"
+
+
 @pytest.mark.skipif(sys.platform != "darwin", reason="Only applies testing on MacOS")
 def test_jvm_mode_change_prevention(popup_handler, gui_widget: NapariImageJMenu):
     """Change jvm_mode on mac from headless to interactive, ensure that is prevented"""
@@ -369,8 +417,9 @@ def test_jvm_mode_change_prevention(popup_handler, gui_widget: NapariImageJMenu)
 
     # Handle the popup from button._update_settings
     expected_text = (
-        "<b>Ignoring selection for setting jvm_mode:</b> "
-        "ImageJ2 must be run headlessly on MacOS. Visit "
+        "<b>Ignoring selection for setting "
+        "<font face='courier'>jvm_mode</font>:</b><p>"
+        "ImageJ2 must be run headlessly on MacOS. <p>Visit "
         '<a href="https://pyimagej.readthedocs.io/en/latest/'
         'Initialization.html#interactive-mode">this site</a> '
         "for more information."


### PR DESCRIPTION
This allows us to fall back to a reasonable default when an empty value is provided, and prevents the user from setting their configuration to a blank directory or endpoint.