### PR TITLE
Update minimum imagej-common to 2.0.2

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - numpy
   - openjdk=8
   - pandas
-  - pyimagej >= 1.3.0
+  - pyimagej >= 1.4.0
   - scyjava >= 1.8.1
   # Developer tools
   - autopep8

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - numpy
   - openjdk=8
   - pandas
-  - pyimagej >= 1.3.0
+  - pyimagej >= 1.4.0
   - scyjava >= 1.8.1
   # Project from source
   - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "napari >= 0.4.17",
     "numpy",
     "pandas",
-    "pyimagej >= 1.3.0",
+    "pyimagej >= 1.4.0",
     "scyjava >= 1.8.1",
 ]
 
@@ -99,5 +99,5 @@ profile = "black"
 [tool.pytest.ini_options]
 env = [
     "NAPARI_IMAGEJ_TESTING=yes",
-    "NAPARI_IMAGEJ_JVM_COMMAND_LINE_ARGUMENTS=-Dfoo=bar"
+    "NAPARI_IMAGEJ_JVM_COMMAND_LINE_ARGUMENTS=-Dfoo=bar",
 ]

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -210,7 +210,7 @@ class ImageJInitializer(QThread):
         # within that component. Thus for each component-version pair, we also need
         # a class to query
         component_requirements: List[Tuple[JClass, str, str]] = [
-            (jc.Dataset, "net.imagej:imagej-common", "0.35.0"),
+            (jc.Dataset, "net.imagej:imagej-common", "2.0.2"),
             (jc.Module, "org.scijava:scijava-common", "2.89.0"),
             (jc.OpInfo, "net.imagej:imagej-ops", "0.48.0"),
         ]

--- a/src/napari_imagej/types/converters/images.py
+++ b/src/napari_imagej/types/converters/images.py
@@ -5,6 +5,7 @@ and napari Images
 
 from typing import Any
 
+from imagej.convert import java_to_xarray
 from imagej.dims import _has_axis
 from jpype import JArray, JByte
 from napari.layers import Image
@@ -24,7 +25,7 @@ def _dataset_view_to_image(image: Any) -> Image:
     view = ij().convert().convert(image, jc.DatasetView)
     # Construct a dataset from the data
     kwargs = dict(
-        data=ij().py.from_java(view.getData().getImgPlus().getImg()),
+        data=java_to_xarray(ij(), view.getData()),
         name=view.getData().getName(),
     )
     if view.getColorTables() and view.getColorTables().size() > 0:

--- a/src/napari_imagej/types/converters/labels.py
+++ b/src/napari_imagej/types/converters/labels.py
@@ -32,7 +32,8 @@ def _layer_to_labeling(layer: Labels):
 
 
 @java_to_py_converter(
-    predicate=lambda obj: isinstance(obj, jc.ImgLabeling), priority=Priority.VERY_HIGH
+    predicate=lambda obj: isinstance(obj, jc.ImgLabeling),
+    priority=Priority.VERY_HIGH + 2,
 )
 def _imglabeling_to_layer(imgLabeling: "jc.ImgLabeling") -> Labels:
     """

--- a/tests/types/test_converters.py
+++ b/tests/types/test_converters.py
@@ -108,9 +108,8 @@ def test_labels_to_labeling(py_labeling):
 
 def test_labels_with_metadata_to_imgLabeling(ij, labels_with_metadata):
     converted: "jc.ImgLabeling" = ij.py.to_java(labels_with_metadata)
-    exp_img: np.ndarray = labels_with_metadata.data
-    act_img: np.ndarray = ij.py.from_java(converted.getIndexImg())
-    assert np.array_equal(exp_img, act_img)
+    act_img: Image = ij.py.from_java(converted.getIndexImg())
+    assert np.array_equal(labels_with_metadata.data, act_img.data)
 
 
 def test_labels_with_metadata_circular(ij, labels_with_metadata):
@@ -121,37 +120,10 @@ def test_labels_with_metadata_circular(ij, labels_with_metadata):
     assert np.array_equal(exp_img, act_img)
 
 
-def _assert_image_mapping(exp_img: np.ndarray, act_img: np.ndarray) -> Dict[int, int]:
-    """
-    Asserts a CONSISTENT mapping between values in exp_img and act_img.
-
-    i.e. if
-    exp_img[x, y] = a and act_img[x, y] = b for any x,y
-    then
-    np.where(exp_img == a) == np.where(act_img == b)
-
-    :param exp_img: the first image
-    :param act_img: the second image
-    :return: the mappings of a -> b
-    """
-    mapping: Dict[int, int] = {}
-    for e_x, a_x in zip(exp_img, act_img):
-        for e, a in zip(e_x, a_x):
-            if e in mapping:
-                assert mapping[e] == a
-            else:
-                mapping[e] = a
-    return mapping
-
-
 def test_labels_without_metadata_to_imgLabeling(ij, labels_without_metadata):
     converted: "jc.ImgLabeling" = ij.py.to_java(labels_without_metadata)
-    exp_img: np.ndarray = labels_without_metadata.data
     act_img: np.ndarray = ij.py.from_java(converted.getIndexImg())
-    # We cannot assert image equality due to
-    # https://github.com/Labelings/Labeling/issues/16
-    # So we do the next best thing
-    _assert_image_mapping(exp_img, act_img)
+    np.array_equal(labels_without_metadata.data, act_img.data)
 
 
 def test_labels_without_metadata_circular(ij, labels_without_metadata):
@@ -159,20 +131,13 @@ def test_labels_without_metadata_circular(ij, labels_without_metadata):
     converted_back: Labels = ij.py.from_java(converted)
     exp_img: np.ndarray = labels_without_metadata.data
     act_img: np.ndarray = converted_back.data
-    # We cannot assert image equality due to
-    # https://github.com/Labelings/Labeling/issues/16
-    # So we do the next best thing
-    _assert_image_mapping(exp_img, act_img)
+    np.array_equal(exp_img, act_img)
 
 
 def test_imgLabeling_to_labels(ij, imgLabeling):
     converted: Labels = ij.py.from_java(imgLabeling)
     exp_img: np.ndarray = ij.py.from_java(imgLabeling.getIndexImg())
-    act_img: np.ndarray = converted.data
-    # We cannot assert image equality due to
-    # https://github.com/Labelings/Labeling/issues/16
-    # So we do the next best thing
-    _assert_image_mapping(exp_img, act_img)
+    np.array_equal(exp_img.data, converted.data)
 
 
 # -- SHAPES / ROIS -- #

--- a/tests/types/test_type_conversions.py
+++ b/tests/types/test_type_conversions.py
@@ -44,14 +44,14 @@ def test_convertible_match_pairs():
     # could be satisfied by a List[float], as napari-imagej knows how to
     # convert that List[float] into a Double[], and imagej knows how to
     # convert that Double[] into a DoubleArray. Unfortunately, DefaultConverter
-    # can convert Integers into DoubleArrays; because it comes first in
+    # can convert Booleans into DoubleArrays; because it comes first in
     # TypeMappings, it is the python type that returns.
     # This is really not napari-imagej's fault.
     # Since the goal was just to test that python_type_of uses ij.convert()
     # as an option, we will leave the conversion like this.
     assert jc.DoubleArray not in hint_map().items()
     input_item = DummyModuleItem(jtype=jc.DoubleArray, isInput=True, isOutput=False)
-    assert _module_utils.type_hint_for(input_item) == int
+    assert _module_utils.type_hint_for(input_item) == bool
 
     # We want to test that napari could tell that a DoubleArray ModuleItem
     # could be satisfied by a List[float], as napari-imagej knows how to
@@ -70,7 +70,7 @@ def test_convertible_match_pairs():
     # gets converted to a ptype
     assert jc.DoubleArray not in hint_map().items()
     input_item = DummyModuleItem(jtype=jc.DoubleArray, isInput=True, isOutput=True)
-    assert _module_utils.type_hint_for(input_item) == List[float]
+    assert _module_utils.type_hint_for(input_item) == List[bool]
 
 
 def test_python_type_of_enum_like_IO():

--- a/tests/widgets/test_searchbar.py
+++ b/tests/widgets/test_searchbar.py
@@ -1,14 +1,20 @@
 """
 A module testing napari_imagej.widgets.searchbar
 """
+import pytest
 from qtpy.QtWidgets import QHBoxLayout, QLineEdit
 
-from napari_imagej.widgets.searchbar import JLineEdit, JVMEnabledSearchbar
+from napari_imagej.widgets.napari_imagej import NapariImageJWidget
+from napari_imagej.widgets.searchbar import JLineEdit
 
 
-def test_searchbar_widget_layout():
+@pytest.fixture
+def searchbar(imagej_widget: NapariImageJWidget):
+    return imagej_widget.search
+
+
+def test_searchbar_widget_layout(searchbar):
     """Tests the number and expected order of search widget children"""
-    searchbar: JVMEnabledSearchbar = JVMEnabledSearchbar()
     subwidgets = searchbar.children()
     assert len(subwidgets) == 2
     assert isinstance(subwidgets[0], QHBoxLayout)


### PR DESCRIPTION
This bump will allow for better java -> python DatasetView conversion.

Unfortunately, we can't merge this PR until pom-scijava includes imagej-common>=2.0.2