### PR TITLE
Ensure napari layers appear (on Windows)

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - jpype1 >= 1.4.1
   - labeling >= 0.1.12
   - magicgui >= 0.5.1
-  - napari
+  - napari >= 0.4.17
   - numpy
   - openjdk=8
   - pyimagej >= 1.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - jpype1 >= 1.4.1
   - labeling >= 0.1.12
   - magicgui >= 0.5.1
-  - napari
+  - napari >= 0.4.17
   - numpy
   - openjdk=8
   - pyimagej >= 1.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "jpype1 >= 1.4.1",
     "labeling >= 0.1.12",
     "magicgui >= 0.5.1",
-    "napari",
+    "napari >= 0.4.17",
     "numpy",
     "pyimagej >= 1.3.0",
     "scyjava >= 1.8.1",

--- a/src/napari_imagej/utilities/_module_utils.py
+++ b/src/napari_imagej/utilities/_module_utils.py
@@ -321,8 +321,6 @@ def _pure_module_outputs(
             widget_outputs.append((name, output))
 
     # napari cannot handle empty List[Layer], so we return None if empty
-    if not len(layer_outputs):
-        layer_outputs = None
     return (layer_outputs, widget_outputs)
 
 
@@ -506,9 +504,8 @@ def functionify_module_execution(
                     module, unresolved_inputs
                 )
                 # log outputs
-                if layer_outputs is not None:
-                    for layer in layer_outputs:
-                        log_debug(f"Result: ({type(layer).__name__}) {layer.name}")
+                for layer in layer_outputs:
+                    log_debug(f"Result: ({type(layer).__name__}) {layer.name}")
                 for output in widget_outputs:
                     log_debug(f"Result: ({type(output[1])}) {output[0]}")
 

--- a/tests/utilities/test_module_utils.py
+++ b/tests/utilities/test_module_utils.py
@@ -498,12 +498,9 @@ widget_parameterizations = [
 )
 def test_module_outputs_number(ij, tmp_path, script, num_layer, num_widget, args):
     layer_outputs, widget_outputs = run_module_from_script(ij, tmp_path, script, args)
-    if num_layer == 0:
-        assert layer_outputs is None
-    else:
-        assert num_layer == len(layer_outputs)
-        for layer in layer_outputs:
-            assert isinstance(layer, Layer)
+    assert num_layer == len(layer_outputs)
+    for layer in layer_outputs:
+        assert isinstance(layer, Layer)
     assert num_widget == len(widget_outputs)
 
 


### PR DESCRIPTION
Since this was a bug in napari, we need to depend on the new napari version. We also don't need to return `None` from our magicgui widget, since napari can handle empty `List[Layer]` returns.