### PR TITLE
Propagate the idea of type HINTS

### DIFF
--- a/src/napari_imagej/types/type_conversions.py
+++ b/src/napari_imagej/types/type_conversions.py
@@ -24,7 +24,7 @@ from scyjava import Priority
 from napari_imagej.java import ij, jc
 from napari_imagej.types.enum_likes import enum_like
 from napari_imagej.types.enums import py_enum_for
-from napari_imagej.types.mappings import ptypes
+from napari_imagej.types.type_hints import hint_map
 from napari_imagej.widgets.parameter_widgets import widget_supported_java_types
 
 # List of Module Item Converters, along with their priority
@@ -49,8 +49,8 @@ def module_item_converter(
     return converter
 
 
-def python_type_of(module_item: "jc.ModuleItem"):
-    """Returns the Python type associated with the passed ModuleItem."""
+def type_hint_for(module_item: "jc.ModuleItem"):
+    """Returns a python type hint for the passed Java ModuleItem."""
     for converter, _ in sorted(
         _MODULE_ITEM_CONVERTERS, reverse=True, key=lambda x: x[1]
     ):
@@ -59,7 +59,7 @@ def python_type_of(module_item: "jc.ModuleItem"):
             return converted
     raise ValueError(
         (
-            f"Unsupported Java Type: {module_item.getType()}. "
+            f"Cannot determine python type hint of {module_item.getType()}. "
             "Let us know about the failure at https://forum.image.sc, "
             "or file an issue at https://github.com/imagej/napari-imagej!"
         )
@@ -117,7 +117,7 @@ def _checkerUsingFunc(
     """
     The logic of this checker is as follows:
 
-    type_mappings().ptypes.items() contains (java_type, python_type) pairs.
+    hint_map.items() contains (java_type, python_type) pairs.
     These pairs are considered to be equivalent types; i.e. we can freely
     convert between these types.
 
@@ -140,7 +140,7 @@ def _checkerUsingFunc(
     """
     # Get the type of the Module item
     java_type = item.getType()
-    type_pairs = ptypes().items()
+    type_pairs = hint_map().items()
     # Case 1
     if item.isInput() and not item.isOutput():
         for jtype, ptype in type_pairs:

--- a/src/napari_imagej/types/type_hints.py
+++ b/src/napari_imagej/types/type_hints.py
@@ -1,7 +1,13 @@
 """
-The definitive set of equivalent Java and Python types.
+The definitive set of HARDCODED python type hints for java types.
 
-The mappings are broken up into sub-maps for convenience and utility.
+The type hints may be concrete types OR strings that can be treated
+as forward references.
+
+Note that many types don't belong here, as they can be determined
+in a programmatic way. Those types should be declared elsewhere.
+
+The hint maps are broken up into sub-maps for convenience and utility.
 """
 from collections import OrderedDict
 from functools import lru_cache
@@ -29,7 +35,7 @@ def map_category(func: Callable[[], Dict[Any, Any]]) -> Callable[[], Dict[Any, A
 
 
 @lru_cache(maxsize=None)
-def ptypes() -> OrderedDict:
+def hint_map() -> OrderedDict:
     types = OrderedDict()
     for generator in MAP_GENERATORS:
         for k, v in generator().items():

--- a/src/napari_imagej/types/type_utils.py
+++ b/src/napari_imagej/types/type_utils.py
@@ -1,17 +1,17 @@
 """
 A module containing useful functions for operating on python types
 """
-from napari_imagej.types import mappings
+from napari_imagej.types import type_hints
 
 
 def _napari_layer_types():
     """A hardcoded set of types that should be displayable in napari"""
     return {
-        **mappings.images(),
-        **mappings.points(),
-        **mappings.shapes(),
-        **mappings.surfaces(),
-        **mappings.labels(),
+        **type_hints.images(),
+        **type_hints.points(),
+        **type_hints.shapes(),
+        **type_hints.surfaces(),
+        **type_hints.labels(),
     }.keys()
 
 

--- a/src/napari_imagej/utilities/_module_utils.py
+++ b/src/napari_imagej/utilities/_module_utils.py
@@ -22,7 +22,7 @@ from napari.utils._magicgui import find_viewer_ancestor
 from scyjava import JavaIterable, JavaMap, JavaSet, is_arraylike, isjava, jstacktrace
 
 from napari_imagej.java import ij, jc
-from napari_imagej.types.type_conversions import python_type_of
+from napari_imagej.types.type_conversions import type_hint_for
 from napari_imagej.types.type_utils import type_displayable_in_napari
 from napari_imagej.types.widget_mappings import preferred_widget_for
 from napari_imagej.utilities.logging import log_debug
@@ -133,7 +133,7 @@ def _resolvable_or_required(input: "jc.ModuleItem"):
     # The ModuleItem is resolvable iff python_type_of
     # does not throw a ValueError.
     try:
-        python_type_of(input)
+        type_hint_for(input)
         return True
     except ValueError:
         return False
@@ -246,7 +246,7 @@ def _type_hint_for_module_item(input: "jc.ModuleItem") -> type:
     """
     Gets the (Python) type hint for a (Java) input
     """
-    type = python_type_of(input)
+    type = type_hint_for(input)
     if not input.isRequired():
         type = Optional[type]
     return type
@@ -382,7 +382,7 @@ def _add_napari_metadata(
 
     # Add the type hints as annotations metadata as well.
     # Without this, magicgui doesn't pick up on the types.
-    type_hints = {str(i.getName()): python_type_of(i) for i in unresolved_inputs}
+    type_hints = {str(i.getName()): type_hint_for(i) for i in unresolved_inputs}
 
     type_hints["return"] = signature(execute_module).return_annotation
 

--- a/tests/types/test_converters.py
+++ b/tests/types/test_converters.py
@@ -12,7 +12,7 @@ from napari.layers import Image, Labels, Points, Shapes, Surface
 from napari_imagej.types.converters.labels import _labeling_to_layer, _layer_to_labeling
 from napari_imagej.types.enum_likes import OutOfBoundsFactory
 from napari_imagej.types.enums import _ENUMS, py_enum_for
-from napari_imagej.types.type_conversions import python_type_of
+from napari_imagej.types.type_conversions import type_hint_for
 from tests.utils import DummyModuleItem, jc
 
 
@@ -735,7 +735,7 @@ def test_enum_conversion_on_the_fly(ij):
 def test_OutOfBoundsFactory_conversion(ij):
     # Test python_type_of
     assert (
-        python_type_of(DummyModuleItem(jtype=jc.OutOfBoundsFactory))
+        type_hint_for(DummyModuleItem(jtype=jc.OutOfBoundsFactory))
         == OutOfBoundsFactory
     )
     # Test conversion

--- a/tests/types/test_type_conversions.py
+++ b/tests/types/test_type_conversions.py
@@ -7,36 +7,36 @@ import pytest
 from jpype import JObject
 
 from napari_imagej.types.enum_likes import OutOfBoundsFactory
-from napari_imagej.types.mappings import ptypes
+from napari_imagej.types.type_hints import hint_map
 from napari_imagej.utilities import _module_utils
 from tests.utils import DummyModuleItem, jc
 
 
 def test_direct_match_pairs():
-    for jtype, ptype in ptypes().items():
+    for jtype, ptype in hint_map().items():
         # Test that jtype inputs convert to ptype inputs
         input_item = DummyModuleItem(jtype=jtype, isInput=True, isOutput=False)
-        assert _module_utils.python_type_of(input_item) == ptype
+        assert _module_utils.type_hint_for(input_item) == ptype
         # Test that jtype outputs convert to ptype outputs
         output_item = DummyModuleItem(jtype=jtype, isInput=False, isOutput=True)
-        assert _module_utils.python_type_of(output_item) == ptype
+        assert _module_utils.type_hint_for(output_item) == ptype
         # Test that jtype boths convert to ptype boths
         IO_item = DummyModuleItem(jtype=jtype, isInput=True, isOutput=True)
-        assert _module_utils.python_type_of(IO_item) == ptype
+        assert _module_utils.type_hint_for(IO_item) == ptype
 
 
 def test_assignable_match_pairs():
     # Test that a java input NOT in ptypes but assignable to some type in ptypes
     # gets converted to a ptype
-    assert jc.ArrayImg not in ptypes().items()
+    assert jc.ArrayImg not in hint_map().items()
     input_item = DummyModuleItem(jtype=jc.ArrayImg, isInput=True, isOutput=False)
-    assert _module_utils.python_type_of(input_item) == "napari.layers.Image"
+    assert _module_utils.type_hint_for(input_item) == "napari.layers.Image"
 
     # Test that a java output NOT in ptypes but assignable from some type in ptypes
     # gets converted to a ptype
-    assert jc.EuclideanSpace not in ptypes().items()
+    assert jc.EuclideanSpace not in hint_map().items()
     output_item = DummyModuleItem(jtype=jc.EuclideanSpace, isInput=False, isOutput=True)
-    assert _module_utils.python_type_of(output_item) == "napari.layers.Shapes"
+    assert _module_utils.type_hint_for(output_item) == "napari.layers.Shapes"
 
 
 def test_convertible_match_pairs():
@@ -49,9 +49,9 @@ def test_convertible_match_pairs():
     # This is really not napari-imagej's fault.
     # Since the goal was just to test that python_type_of uses ij.convert()
     # as an option, we will leave the conversion like this.
-    assert jc.DoubleArray not in ptypes().items()
+    assert jc.DoubleArray not in hint_map().items()
     input_item = DummyModuleItem(jtype=jc.DoubleArray, isInput=True, isOutput=False)
-    assert _module_utils.python_type_of(input_item) == int
+    assert _module_utils.type_hint_for(input_item) == int
 
     # We want to test that napari could tell that a DoubleArray ModuleItem
     # could be satisfied by a List[float], as napari-imagej knows how to
@@ -62,15 +62,15 @@ def test_convertible_match_pairs():
     # This is really not napari-imagej's fault.
     # Since the goal was just to test that python_type_of uses ij.convert()
     # as an option, we will leave the conversion like this.
-    assert jc.DoubleArray not in ptypes().items()
+    assert jc.DoubleArray not in hint_map().items()
     input_item = DummyModuleItem(jtype=jc.DoubleArray, isInput=False, isOutput=True)
-    assert _module_utils.python_type_of(input_item) == str
+    assert _module_utils.type_hint_for(input_item) == str
 
     # Test that a java both NOT in ptypes but convertible to/from some type in ptypes
     # gets converted to a ptype
-    assert jc.DoubleArray not in ptypes().items()
+    assert jc.DoubleArray not in hint_map().items()
     input_item = DummyModuleItem(jtype=jc.DoubleArray, isInput=True, isOutput=True)
-    assert _module_utils.python_type_of(input_item) == List[float]
+    assert _module_utils.type_hint_for(input_item) == List[float]
 
 
 def test_python_type_of_enum_like_IO():
@@ -78,26 +78,26 @@ def test_python_type_of_enum_like_IO():
     module_item = DummyModuleItem(
         jtype=jc.OutOfBoundsFactory, isInput=True, isOutput=False
     )
-    assert _module_utils.python_type_of(module_item) == OutOfBoundsFactory
+    assert _module_utils.type_hint_for(module_item) == OutOfBoundsFactory
 
     # Test that a mutable input does not match
     module_item._isOutput = True
     try:
-        _module_utils.python_type_of(module_item)
+        _module_utils.type_hint_for(module_item)
         pytest.fail()
     except ValueError:
         pass
 
     # Test that a pure output does not match the enum
     module_item._isInput = False
-    assert _module_utils.python_type_of(module_item) == str
+    assert _module_utils.type_hint_for(module_item) == str
 
 
 def test_enum():
-    p_type = _module_utils.python_type_of(DummyModuleItem(jtype=jc.ItemIO))
+    p_type = _module_utils.type_hint_for(DummyModuleItem(jtype=jc.ItemIO))
     assert p_type.__name__ == "ItemIO"
 
 
 def test_shape():
-    p_type = _module_utils.python_type_of(DummyModuleItem(jtype=jc.Shape))
+    p_type = _module_utils.type_hint_for(DummyModuleItem(jtype=jc.Shape))
     assert p_type == JObject

--- a/tests/types/test_widget_mappings.py
+++ b/tests/types/test_widget_mappings.py
@@ -20,7 +20,7 @@ from napari_imagej.types.widget_mappings import (
     _supported_scijava_styles,
     preferred_widget_for,
 )
-from napari_imagej.utilities._module_utils import python_type_of
+from napari_imagej.utilities._module_utils import type_hint_for
 from napari_imagej.widgets.parameter_widgets import (
     DirectoryWidget,
     MutableOutputWidget,
@@ -113,23 +113,23 @@ def test_file_widgets():
     # FileWidget.OPEN_STYLE
     item = DummyModuleItem(jtype=jc.File)
     item.setWidgetStyle(jc.FileWidget.OPEN_STYLE)
-    type_hint = python_type_of(item)
+    type_hint = type_hint_for(item)
     assert preferred_widget_for(item, type_hint) == OpenFileWidget
 
     # FileWidget.SAVE_STYLE
     item = DummyModuleItem(jtype=jc.File)
     item.setWidgetStyle(jc.FileWidget.SAVE_STYLE)
-    type_hint = python_type_of(item)
+    type_hint = type_hint_for(item)
     assert preferred_widget_for(item, type_hint) == SaveFileWidget
 
     # FileWidget.DIRECTORY_STYLE
     item = DummyModuleItem(jtype=jc.File)
     item.setWidgetStyle(jc.FileWidget.DIRECTORY_STYLE)
-    type_hint = python_type_of(item)
+    type_hint = type_hint_for(item)
     assert preferred_widget_for(item, type_hint) == DirectoryWidget
 
 
 def test_shape_widget():
     item = DummyModuleItem(jtype=jc.Shape)
-    type_hint = python_type_of(item)
+    type_hint = type_hint_for(item)
     assert preferred_widget_for(item, type_hint) == ShapeWidget

--- a/tests/utilities/test_module_utils.py
+++ b/tests/utilities/test_module_utils.py
@@ -11,7 +11,7 @@ from magicgui.widgets import Container, Label, LineEdit, Widget
 from napari import Viewer
 from napari.layers import Image, Layer
 
-from napari_imagej.types.mappings import ptypes
+from napari_imagej.types.type_hints import hint_map
 from napari_imagej.types.type_utils import _napari_layer_types
 from napari_imagej.utilities import _module_utils
 from tests.utils import DummyModuleItem, jc
@@ -161,7 +161,7 @@ def test_napari_param_new_window_checkbox():
     for t in types_absent:
         assert_new_window_checkbox_for_type(t, False)
 
-    types_present = list(set(ptypes().keys()) - set(_napari_layer_types()))
+    types_present = list(set(hint_map().keys()) - set(_napari_layer_types()))
     for t in types_present:
         assert_new_window_checkbox_for_type(t, True)
 


### PR DESCRIPTION
Lots of our Java -> Python type logic talked about the idea of a type MAPPING. I don't like this wording, since it implies you get a TYPE out if you put a type in. You don't; you get a type OR A STRING out, i.e. a type hint. Let's talk about a hint instead