### PR TITLE
Clear ResultRunner upon new search

### DIFF
--- a/src/napari_imagej/widgets/napari_imagej.py
+++ b/src/napari_imagej/widgets/napari_imagej.py
@@ -50,6 +50,7 @@ class NapariImageJWidget(QWidget):
 
         # When the text bar changes, update the search results.
         self.search.bar.textEdited.connect(self.result_tree.search)
+        self.search.bar.textEdited.connect(self.result_runner.clear)
 
         # When clicking a result, select it with the ResultRunner
         def click(treeItem: QTreeWidgetItem):


### PR DESCRIPTION
This PR closes #52.

Since now the search results are all in one `QTreeWidget`, we don't have the multiple selection anymore.

The one line added clears the "staged" selection when searching new text.