### PR TITLE
Display ImageJ2 version upon initialization

### DIFF
--- a/src/napari_imagej/widgets/info_bar.py
+++ b/src/napari_imagej/widgets/info_bar.py
@@ -1,0 +1,13 @@
+"""
+A display showing information relative to the napari-imagej widget
+"""
+from qtpy.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class InfoBox(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setLayout(QVBoxLayout())
+        # Label for displaying ImageJ version
+        self.version_bar = QLabel()
+        self.layout().addWidget(self.version_bar)

--- a/src/napari_imagej/widgets/napari_imagej.py
+++ b/src/napari_imagej/widgets/napari_imagej.py
@@ -11,6 +11,7 @@ from qtpy.QtWidgets import QMessageBox, QTreeWidgetItem, QVBoxLayout, QWidget
 from scyjava import when_jvm_stops
 
 from napari_imagej.java import ij, init_ij_async, java_signals, jc
+from napari_imagej.widgets.info_bar import InfoBox
 from napari_imagej.widgets.menu import NapariImageJMenu
 from napari_imagej.widgets.result_runner import ResultRunner
 from napari_imagej.widgets.result_tree import (
@@ -42,9 +43,12 @@ class NapariImageJWidget(QWidget):
         # Then: The results tree
         self.result_tree: SearchResultTree = SearchResultTree()
         self.layout().addWidget(self.result_tree)
-        # Finally: The SearchResult runner
+        # Second-to-lastly: The SearchResult runner
         self.result_runner: ResultRunner = ResultRunner(napari_viewer)
         self.layout().addWidget(self.result_runner)
+        # Finally: The InfoBar
+        self.info_box: InfoBox = InfoBox()
+        self.layout().addWidget(self.info_box)
 
         # -- Interwidget connections -- #
 
@@ -136,6 +140,8 @@ class WidgetFinalizer(QThread):
         """
         # Finalize the Results Tree
         self._finalize_results_tree()
+        # Finalize the info bar
+        self._finalize_info_bar()
 
     def _finalize_results_tree(self):
         """
@@ -177,3 +183,8 @@ class WidgetFinalizer(QThread):
                     expanded=False,
                 )
             )
+
+    def _finalize_info_bar(self):
+        self.widget.info_box.version_bar.setText(
+            " ".join(["ImageJ", str(ij().getVersion())])
+        )

--- a/tests/widgets/test_info_bar.py
+++ b/tests/widgets/test_info_bar.py
@@ -1,0 +1,23 @@
+"""
+A module testing napari_imagej.widgets.info_bar
+"""
+import pytest
+from qtpy.QtWidgets import QLabel, QVBoxLayout
+
+from napari_imagej.widgets.info_bar import InfoBox
+
+
+@pytest.fixture
+def info_bar():
+    return InfoBox()
+
+
+def test_widget_layout(info_bar: InfoBox):
+    """Tests the number and expected order of InfoBar children"""
+    subwidgets = info_bar.children()
+    assert len(subwidgets) == 2
+    assert isinstance(info_bar.layout(), QVBoxLayout)
+    assert isinstance(subwidgets[0], QVBoxLayout)
+
+    assert isinstance(subwidgets[1], QLabel)
+    assert subwidgets[1].text() == ""

--- a/tests/widgets/test_napari_imagej.py
+++ b/tests/widgets/test_napari_imagej.py
@@ -7,6 +7,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication, QPushButton, QVBoxLayout
 
 from napari_imagej.java import ij, jc
+from napari_imagej.widgets.info_bar import InfoBox
 from napari_imagej.widgets.menu import NapariImageJMenu
 from napari_imagej.widgets.napari_imagej import NapariImageJWidget, ResultRunner
 from napari_imagej.widgets.result_tree import SearchResultTree
@@ -17,7 +18,7 @@ from tests.widgets.widget_utils import _searcher_tree_named
 def test_widget_subwidget_layout(imagej_widget: NapariImageJWidget):
     """Tests the number and expected order of imagej_widget children"""
     subwidgets = imagej_widget.children()
-    assert len(subwidgets) == 5
+    assert len(subwidgets) == 6
     assert isinstance(imagej_widget.layout(), QVBoxLayout)
     assert isinstance(subwidgets[0], QVBoxLayout)
 
@@ -25,6 +26,7 @@ def test_widget_subwidget_layout(imagej_widget: NapariImageJWidget):
     assert isinstance(subwidgets[2], JVMEnabledSearchbar)
     assert isinstance(subwidgets[3], SearchResultTree)
     assert isinstance(subwidgets[4], ResultRunner)
+    assert isinstance(subwidgets[5], InfoBox)
 
 
 def test_keymaps(make_napari_viewer, qtbot):
@@ -201,3 +203,17 @@ def test_widget_clearing(imagej_widget: NapariImageJWidget, qtbot, asserter):
     # Wait for the buttons to disappear
     asserter(imagej_widget.result_runner.selected_module_label.isHidden)
     asserter(lambda: len(_run_buttons(imagej_widget)) == 0)
+
+
+def test_info_validity(imagej_widget: NapariImageJWidget, qtbot, asserter):
+    """
+    Ensures that searching something clears the result runner
+    """
+
+    # Wait for the info to populate
+    ij()
+
+    # Check the version
+    info_box = imagej_widget.info_box
+
+    asserter(lambda: info_box.version_bar.text() == "ImageJ " + str(ij().getVersion()))


### PR DESCRIPTION
This PR adds a new subwidget that is capable of displaying plugin information like the ImageJ version. This subwidget is displayed at the bottom of the plugin, as shown below.

![image](https://user-images.githubusercontent.com/29754838/208179656-9f7eb31d-b83b-4cca-b136-d3a72ba270cb.png)

@ctrueden if you like this, please feel free to merge.