### PR TITLE
Bump Maximum Python version to 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.10']
+        python-version: ['3.8', '3.11']
 
     steps:
       - uses: actions/checkout@v2
@@ -121,7 +121,7 @@ jobs:
         with:
           # Create env with dev packages
           auto-update-conda: true
-          python-version: 3.9
+          python-version: 3.11
           miniforge-variant: Mambaforge
           environment-file: dev-environment.yml
           # Activate napari-imagej-dev environment
@@ -167,7 +167,7 @@ jobs:
         with:
           # Create env with dev packages
           auto-update-conda: true
-          python-version: 3.9
+          python-version: 3.11
           miniforge-variant: Mambaforge
           environment-file: dev-environment.yml
           # Activate napari-imagej-dev environment

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - scyjava >= 1.8.1
   # Developer tools
   - autopep8
-  - black
+  - black >= 23.1.0
   - build
   - flake8
   - flake8-typing-imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 # Development tools
 dev = [
     "autopep8",
-    "black",
+    "black >= 23.1.0",
     "build",
     "flake8",
     "flake8-pyproject",

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -17,7 +17,7 @@ from threading import Lock
 from typing import Any, Callable, Dict, List, Tuple
 
 import imagej
-from jpype import JClass
+from jpype import JClass, JImplementationFor
 from qtpy.QtCore import QObject, QThread, Signal
 from scyjava import config, get_version, is_version_at_least, jimport, jvm_started
 
@@ -730,3 +730,25 @@ class JavaClasses(object):
 
 
 jc = JavaClasses()
+
+
+@JImplementationFor("org.scijava.module.ModuleItem")
+class ModuleItemAddons(object):
+    """ModuleItem addons.
+
+    This class should not be initialized manually. Upon initialization
+    the ImagePlusAddons class automatically extends the Java
+    ij.ImagePlus via JPype's class customization mechanism:
+
+    https://jpype.readthedocs.io/en/latest/userguide.html#class-customizers
+    """
+
+    # RESTRICTED_NAMES = {
+    #     "in": "input",
+    # }
+
+    def py_name(self):
+        name = self.getName()
+        if name == "in":
+            return "input"
+        return name

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -748,7 +748,7 @@ class ModuleItemAddons(object):
     # }
 
     def py_name(self):
-        name = self.getName()
+        name = ij().py.from_java(self.getName())
         if name == "in":
             return "input"
         return name

--- a/src/napari_imagej/utilities/_module_utils.py
+++ b/src/napari_imagej/utilities/_module_utils.py
@@ -334,7 +334,6 @@ def _napari_specific_parameter(func: Callable, args: Tuple[Any], param: str) -> 
 
 
 def _non_layer_widget(results: List[Tuple[str, Any]]) -> Widget:
-
     widgets = []
     for result in results:
         name = result[0]

--- a/src/napari_imagej/utilities/_module_utils.py
+++ b/src/napari_imagej/utilities/_module_utils.py
@@ -255,7 +255,7 @@ def _type_hint_for_module_item(input: "jc.ModuleItem") -> type:
 def _module_param(input: "jc.ModuleItem") -> Parameter:
     """Converts a java ModuleItem into a python Parameter"""
     # NB ModuleInfo.py_name() defined using JImplementationFor
-    name = ij().py.from_java(input.py_name())
+    name = input.py_name()
     kind = Parameter.POSITIONAL_OR_KEYWORD
     default = _param_default_or_none(input)
     type_hint = _type_hint_for_module_item(input)

--- a/src/napari_imagej/utilities/_module_utils.py
+++ b/src/napari_imagej/utilities/_module_utils.py
@@ -254,7 +254,8 @@ def _type_hint_for_module_item(input: "jc.ModuleItem") -> type:
 
 def _module_param(input: "jc.ModuleItem") -> Parameter:
     """Converts a java ModuleItem into a python Parameter"""
-    name = ij().py.from_java(input.getName())
+    # NB ModuleInfo.py_name() defined using JImplementationFor
+    name = ij().py.from_java(input.py_name())
     kind = Parameter.POSITIONAL_OR_KEYWORD
     default = _param_default_or_none(input)
     type_hint = _type_hint_for_module_item(input)

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -304,7 +304,6 @@ class GUIButton(QPushButton):
 
 
 class SettingsButton(QPushButton):
-
     # Signal used to identify changes to user settings
     setting_change = Signal()
 

--- a/src/napari_imagej/widgets/result_tree.py
+++ b/src/napari_imagej/widgets/result_tree.py
@@ -87,7 +87,6 @@ class SearcherTreeItem(QTreeWidgetItem):
 
 
 class SearchResultTree(QTreeWidget):
-
     # Signal used to update the children of this widget.
     # NB the object passed in this signal's emissions will always be a
     # org.scijava.search.SearchEvent in practice. BUT the signal requires

--- a/tests/types/test_converters.py
+++ b/tests/types/test_converters.py
@@ -27,7 +27,6 @@ def assert_labels_equality(
 
 @pytest.fixture(scope="module")
 def py_labeling() -> Labeling:
-
     a = np.zeros((4, 4), np.int32)
     a[:2] = 1
     example1_images = []

--- a/tests/types/test_widget_mappings.py
+++ b/tests/types/test_widget_mappings.py
@@ -85,7 +85,6 @@ def test_preferred_widget_for(style, type_hint, widget_type, widget_class):
     ["napari.layers.Image", Image, Optional["napari.layers.Image"], Optional[Image]],
 )
 def test_preferred_widget_for_parameter_widgets(type_hint):
-
     # MutableOutputWidget
     item: DummyModuleItem = DummyModuleItem(
         jtype=jc.ArrayImg, isInput=True, isOutput=True

--- a/tests/utilities/test_module_utils.py
+++ b/tests/utilities/test_module_utils.py
@@ -209,6 +209,15 @@ def test_module_param():
     assert expected == _module_utils._module_param(module_item)
 
 
+def test_module_param_illegal_name():
+    """Ensure illegal param names in python are renamed"""
+    module_item = DummyModuleItem(jtype=jc.String, name="in")
+    expected = Parameter(
+        name="input", kind=Parameter.POSITIONAL_OR_KEYWORD, annotation=str
+    )
+    assert expected == _module_utils._module_param(module_item)
+
+
 def test_add_param_metadata():
     # Test successful addition
     metadata = {}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ from typing import List
 
 from jpype import JImplements, JOverride
 
-from napari_imagej.java import JavaClasses
+from napari_imagej.java import JavaClasses, ModuleItemAddons
 
 
 class JavaClassesTest(JavaClasses):
@@ -170,7 +170,7 @@ class DummyModuleInfo:
         return self._outputs
 
 
-class DummyModuleItem:
+class DummyModuleItem(ModuleItemAddons):
     """
     A mock of org.scijava.module.ModuleItem that is created much easier
     Fields can and should be added as needed for tests.

--- a/tests/widgets/test_menu.py
+++ b/tests/widgets/test_menu.py
@@ -74,7 +74,6 @@ def popup_handler(asserter) -> Callable[[str, Callable[[], None]], None]:
     def handle_popup(text: str, popup_generator: Callable[[], None]):
         # # Start the handler in a new thread
         class Handler(QRunnable):
-
             # Test popup when running headlessly
             def run(self) -> None:
                 asserter(lambda: isinstance(QApplication.activeWindow(), RichTextPopup))
@@ -203,7 +202,6 @@ def test_GUIButton_layout_headless(popup_handler, gui_widget: NapariImageJMenu):
 
 @pytest.mark.skipif(TESTING_HEADLESS, reason="Only applies when not running headlessly")
 def test_active_data_send(asserter, qtbot, ij, gui_widget: NapariImageJMenu):
-
     button: ToIJButton = gui_widget.to_ij
     assert not button.isEnabled()
 


### PR DESCRIPTION
While napari is still working on 3.11 support (see napari/napari#5439), a default napari-imagej conda install will install Python 3.11 :frowning_face: 

Fortunately, all the tests pass, so we can *probably* just bump the CI job to run on 3.11 and be fine. Unfortunately, I'm running into a parameter naming issue, described in #166. So we should probably fix that here.