### PR TITLE
Prevent ImageJ legacy GUI from disposing context

### DIFF
--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -86,12 +86,15 @@ class NapariImageJMenu(QWidget):
 
     def _ij2_UI_setup(self):
         """Configures the ImageJ2 Swing GUI behavior"""
-        appFrame = self.gui.getApplicationFrame()
         # Overwrite the WindowListeners so we control closing behavior
+        self._kill_window_listeners(self._get_AWT_frame())
+
+    def _get_AWT_frame(self):
+        appFrame = self.gui.getApplicationFrame()
         if isinstance(appFrame, jc.Window):
-            self._kill_window_listeners(appFrame)
+            return appFrame
         elif isinstance(appFrame, jc.UIComponent):
-            self._kill_window_listeners(appFrame.getComponent())
+            return appFrame.getComponent()
 
     def _kill_window_listeners(self, window):
         """Replaces the WindowListeners present on window with our own"""

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -69,8 +69,7 @@ class NapariImageJMenu(QWidget):
                 # Then, add our custom settings to the User Interface
                 if ij().legacy and ij().legacy.isActive():
                     self._ij1_UI_setup()
-                else:
-                    self._ij2_UI_setup()
+                self._ij2_UI_setup()
 
             # Queue UI call on the EDT
             # TODO: Use EventQueue.invokeLater scyjava wrapper, once it exists
@@ -86,7 +85,7 @@ class NapariImageJMenu(QWidget):
         ij().IJ.getInstance().exitWhenQuitting(False)
 
     def _ij2_UI_setup(self):
-        """Configures the ImageJ2 Swing GUI"""
+        """Configures the ImageJ2 Swing GUI behavior"""
         appFrame = self.gui.getApplicationFrame()
         # Overwrite the WindowListeners so we control closing behavior
         if isinstance(appFrame, jc.Window):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -58,6 +58,10 @@ class JavaClassesTest(JavaClasses):
         return "net.imglib2.type.numeric.real.FloatType"
 
     @JavaClasses.blocking_import
+    def Frame(self):
+        return "java.awt.Frame"
+
+    @JavaClasses.blocking_import
     def ImageDisplay(self):
         return "net.imagej.display.ImageDisplay"
 
@@ -108,6 +112,10 @@ class JavaClassesTest(JavaClasses):
     @JavaClasses.blocking_import
     def UnsignedLongType(self):
         return "net.imglib2.type.numeric.integer.UnsignedLongType"
+
+    @JavaClasses.blocking_import
+    def WindowEvent(self):
+        return "java.awt.event.WindowEvent"
 
 
 jc = JavaClassesTest()

--- a/tests/widgets/test_menu.py
+++ b/tests/widgets/test_menu.py
@@ -493,3 +493,28 @@ def test_image_plus_to_napari(asserter, qtbot, ij, gui_widget: NapariImageJMenu)
 
     # Assert the data is in napari
     asserter(lambda: "blobs.gif" in current_viewer().layers)
+
+
+@pytest.mark.skipif(TESTING_HEADLESS, reason="Only applies when not running headlessly")
+def test_opening_and_closing_gui(asserter, qtbot, ij, gui_widget: NapariImageJMenu):
+    # Open the GUI
+    qtbot.mouseClick(gui_widget.gui_button, Qt.LeftButton, delay=1)
+    # Wait for the Frame to be created
+    asserter(lambda: gui_widget._get_AWT_frame() is not None)
+    frame = gui_widget._get_AWT_frame()
+    # Wait for the Frame to be visible
+    asserter(lambda: frame.isVisible())
+
+    # Close the GUI
+    ij.thread().queue(
+        lambda: frame.dispatchEvent(
+            jc.WindowEvent(frame, jc.WindowEvent.WINDOW_CLOSING)
+        )
+    )
+    # Wait for the Frame to be hidden
+    asserter(lambda: not frame.isVisible())
+
+    # Open the GUI again
+    qtbot.mouseClick(gui_widget.gui_button, Qt.LeftButton, delay=1)
+    # Wait for the Frame to be visible again
+    asserter(lambda: frame.isVisible())


### PR DESCRIPTION
This PR ensures that the steps that we *were* taking when launching the ImageJ2 UI *also occur* when launching the legacy UI. This prevents a `Context` disposal when you close the ImageJ legacy UI, enabling further interaction after closing.

TODO: Test.