### PR TITLE
Use str instead of PyImageJ Conversion Framework when creating SearchResultItems

### DIFF
--- a/src/napari_imagej/widgets/result_tree.py
+++ b/src/napari_imagej/widgets/result_tree.py
@@ -21,7 +21,7 @@ class SearchResultTreeItem(QTreeWidgetItem):
 
     def __init__(self, result: "jc.SearchResult"):
         super().__init__()
-        self.name = ij().py.from_java(result.name())
+        self.name = str(result.name())
         self.result = result
 
         # Set QtPy properties


### PR DESCRIPTION
It's much faster, which is important when we could be making thousands of these things.

@hinerm can you confirm that this is much faster for you?