### PR TITLE
Clarify the version in the version bar

### DIFF
--- a/src/napari_imagej/widgets/napari_imagej.py
+++ b/src/napari_imagej/widgets/napari_imagej.py
@@ -214,9 +214,7 @@ class WidgetFinalizer(QThread):
             )
 
     def _finalize_info_bar(self):
-        self.widget.info_box.version_bar.setText(
-            " ".join(["ImageJ", str(ij().getVersion())])
-        )
+        self.widget.info_box.version_bar.setText(f"ImageJ2 v{ij().getVersion()}")
 
     def _finalize_exception_printer(self):
         # HACK: Tap into the EventBus to obtain SciJava Module debug info.

--- a/tests/widgets/test_napari_imagej.py
+++ b/tests/widgets/test_napari_imagej.py
@@ -233,7 +233,7 @@ def test_info_validity(imagej_widget: NapariImageJWidget, qtbot, asserter):
     # Check the version
     info_box = imagej_widget.info_box
 
-    asserter(lambda: info_box.version_bar.text() == "ImageJ " + str(ij().getVersion()))
+    asserter(lambda: info_box.version_bar.text() == f"ImageJ2 v{ij().getVersion()}")
 
 
 def test_handle_output_layer(imagej_widget: NapariImageJWidget, qtbot, asserter):


### PR DESCRIPTION
It's the version of ImageJ2, not the version of the original ImageJ.

(Although if the legacy layer is enabled, the version of the
original ImageJ will also be included, after the slash.)
