### PR TITLE
Add remaining Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
 help:
 	@echo "Available targets:\n\
+		clean - remove build files and directories\n\
+		setup - create mamba developer environment\n\
 		lint  - run code formatters and linters\n\
+		test  - run automated test suite\n\
 		docs  - generate documentation site\n\
 		dist  - generate release archives\n\
 	\n\
 	Remember to 'mamba activate pyimagej-dev' first!"
+
+clean:
+	bin/clean.sh
+
+setup:
+	bin/setup.sh
 
 check:
 	@bin/check.sh
@@ -12,8 +21,11 @@ check:
 lint: check
 	bin/lint.sh
 
+test: check
+	bin/test.sh
+
 docs: check
-	cd doc && $(MAKE) html; cd ..
+	cd doc && $(MAKE) html
 
 dist: check clean
 	python -m build

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+dir=$(dirname "$0")
+cd "$dir/.."
+
+find . -name __pycache__ -type d | while read d
+  do rm -rfv "$d"
+done
+rm -rfv .pytest_cache build dist doc/_build doc/rtd src/*.egg-info

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+dir=$(dirname "$0")
+cd "$dir/.."
+
+mamba env create -f dev-environment.yml

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+dir=$(dirname "$0")
+cd "$dir/.."
+
+if [ $# -gt 0 ]
+then
+  python -m pytest -p no:faulthandler $@
+else
+  python -m pytest -p no:faulthandler tests/
+fi


### PR DESCRIPTION
This brings the simple make-based system in line with the
project dependencies jgo, scyjava, imglyb, and pyimagej.
