### PR TITLE
Simplify handling of ModuleItems named "in"

### DIFF
--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -17,7 +17,7 @@ from threading import Lock
 from typing import Any, Callable, Dict, List, Tuple
 
 import imagej
-from jpype import JClass, JImplementationFor
+from jpype import JClass
 from qtpy.QtCore import QObject, QThread, Signal
 from scyjava import config, get_version, is_version_at_least, jimport, jvm_started
 

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -751,25 +751,3 @@ class JavaClasses(object):
 
 
 jc = JavaClasses()
-
-
-@JImplementationFor("org.scijava.module.ModuleItem")
-class ModuleItemAddons(object):
-    """ModuleItem addons.
-
-    This class should not be initialized manually. Upon initialization
-    the ImagePlusAddons class automatically extends the Java
-    ij.ImagePlus via JPype's class customization mechanism:
-
-    https://jpype.readthedocs.io/en/latest/userguide.html#class-customizers
-    """
-
-    # RESTRICTED_NAMES = {
-    #     "in": "input",
-    # }
-
-    def py_name(self):
-        name = ij().py.from_java(self.getName())
-        if name == "in":
-            return "input"
-        return name

--- a/src/napari_imagej/utilities/_module_utils.py
+++ b/src/napari_imagej/utilities/_module_utils.py
@@ -195,8 +195,11 @@ def _param_default_or_none(input: "jc.ModuleItem") -> Optional[Any]:
 
 def _module_param(input: "jc.ModuleItem") -> Parameter:
     """Converts a java ModuleItem into a python Parameter"""
-    # NB ModuleInfo.py_name() defined using JImplementationFor
-    name = input.py_name()
+    name = str(input.getName())
+    if name == "in":
+        # HACK: The name "in" is a keyword in Python.
+        # So we use the name "input" instead.
+        name = "input"
     kind = Parameter.POSITIONAL_OR_KEYWORD
     default = _param_default_or_none(input)
     type_hint = type_hint_for(input)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ from typing import List
 
 from jpype import JImplements, JOverride
 
-from napari_imagej.java import JavaClasses, ModuleItemAddons
+from napari_imagej.java import JavaClasses
 
 
 class JavaClassesTest(JavaClasses):
@@ -182,7 +182,7 @@ class DummyModuleInfo:
         return self._outputs
 
 
-class DummyModuleItem(ModuleItemAddons):
+class DummyModuleItem:
     """
     A mock of org.scijava.module.ModuleItem that is created much easier
     Fields can and should be added as needed for tests.


### PR DESCRIPTION
There is no need to tack on a new method to the ModuleItem itself.
