### PR TITLE
Improve Dataset Axis settings

### DIFF
--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -692,6 +692,10 @@ class JavaClasses(object):
     # ImageJ2 Types
 
     @blocking_import
+    def Axes(self):
+        return "net.imagej.axis.Axes"
+
+    @blocking_import
     def Dataset(self):
         return "net.imagej.Dataset"
 

--- a/src/napari_imagej/types/converters/images.py
+++ b/src/napari_imagej/types/converters/images.py
@@ -59,23 +59,24 @@ def _dataset_to_image(image: Any) -> Image:
 def _image_to_dataset(image: Image) -> "jc.Dataset":
     # Construct a dataset from the data
     dataset: "jc.Dataset" = ij().py.to_dataset(image.data)
-    # NB We need to match dimensions to axes, or ImageJ2 doesn't know
-    # how to display it.
-    if not ij().legacy or not ij().legacy.isActive():
-        if dataset.dimensionIndex(jc.Axes.X) == -1:
-            # find the first "unknown" dimension
-            for i in range(dataset.numDimensions()):
-                axis = dataset.axis(i)
-                if "dim" in axis.type().getLabel():
-                    axis.setType(jc.Axes.X)
-                    break
-        if dataset.dimensionIndex(jc.Axes.Y) == -1:
-            # find the first "unknown" dimension
-            for i in range(dataset.numDimensions()):
-                axis = dataset.axis(i)
-                if "dim" in axis.type().getLabel():
-                    axis.setType(jc.Axes.Y)
-                    break
+    # We need an "X" axis, or ImageJ2 doesn't know how to display the dataset
+    if dataset.dimensionIndex(jc.Axes.X) == -1:
+        # find the first "unknown" dimension
+        for i in range(dataset.numDimensions()):
+            axis = dataset.axis(i)
+            if "dim" in axis.type().getLabel():
+                # and set it to "X"
+                axis.setType(jc.Axes.X)
+                break
+    # We need an "Y" axis, or ImageJ2 doesn't know how to display the dataset
+    if dataset.dimensionIndex(jc.Axes.Y) == -1:
+        # find the first "unknown" dimension
+        for i in range(dataset.numDimensions()):
+            axis = dataset.axis(i)
+            if "dim" in axis.type().getLabel():
+                # and set it to "Y"
+                axis.setType(jc.Axes.Y)
+                break
 
     # Add name
     dataset.setName(image.name)

--- a/tests/types/test_converters.py
+++ b/tests/types/test_converters.py
@@ -761,9 +761,8 @@ def test_image_layer_to_dataset(ij):
     assert name == j_img.getName()
     assert 0 == j_img.getColorTableCount()
 
-    if not ij.legacy or not ij.legacy.isActive():
-        assert 0 == j_img.dimensionIndex(jc.Axes.X)
-        assert 1 == j_img.dimensionIndex(jc.Axes.Y)
+    assert 0 == j_img.dimensionIndex(jc.Axes.X)
+    assert 1 == j_img.dimensionIndex(jc.Axes.Y)
 
 
 def test_colormap_image_layer_to_dataset(ij):

--- a/tests/types/test_converters.py
+++ b/tests/types/test_converters.py
@@ -761,8 +761,9 @@ def test_image_layer_to_dataset(ij):
     assert name == j_img.getName()
     assert 0 == j_img.getColorTableCount()
 
-    assert 0 == j_img.dimensionIndex(jc.Axes.X)
-    assert 1 == j_img.dimensionIndex(jc.Axes.Y)
+    if not ij.legacy or not ij.legacy.isActive():
+        assert 0 == j_img.dimensionIndex(jc.Axes.X)
+        assert 1 == j_img.dimensionIndex(jc.Axes.Y)
 
 
 def test_colormap_image_layer_to_dataset(ij):


### PR DESCRIPTION
We have to *explicitly* define some axes as `X` and `Y` for the ImageJ2 UI to display a `Dataset`, however the way we were setting it before caused 3+ dimensional images to be rotated. This shouldn't be the case anymore.

I made this change within napari-imagej as (a) we don't even need it unless we are using the ImageJ2 UI, which doesn't happen much and (b) it seemed involved to add the behavior to PyImageJ, after talking with @elevans. If anyone feels strongly that this change should be in PyImageJ (@ctrueden?), we can make that change, and we shouldn't have to make any changes on this side to obtain that behavior.