### PR TITLE
Map active layer to current ij window

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -46,6 +46,7 @@ dependencies:
   - pytest-cov
   - pytest-env
   - pytest-qt
+  - setuptools >= 61.2
   - sphinx
   - sphinx_rtd_theme
   - qtpy

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -51,6 +51,10 @@ def ij():
     return initializer.ij
 
 
+def legacy_active():
+    return ij().legacy and ij().legacy.isActive()
+
+
 class ImageJInitializer(QThread):
     """
     A QThread responsible for initializing ImageJ
@@ -185,6 +189,10 @@ class ImageJInitializer(QThread):
             {"scijava.public": "https://maven.scijava.org/content/groups/public"}
         )
         config.add_option(f"-Dimagej2.dir={settings['imagej_base_directory'].get(str)}")
+        config.add_option(
+            "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8579"
+        )
+        config.endpoints.append("net.imagej:ij:1.x-SNAPSHOT")
 
         # Append napari-imagej-specific cli arguments
         cli_args = settings["jvm_command_line_arguments"].get(str)
@@ -732,6 +740,20 @@ class JavaClasses(object):
     @blocking_import
     def ImagePlus(self):
         return "ij.ImagePlus"
+
+    # ImageJ Legacy Types
+
+    @blocking_import
+    def Harmonizer(self):
+        return "net.imagej.legacy.translate.Harmonizer"
+
+    @blocking_import
+    def ImageTranslator(self):
+        return "net.imagej.legacy.translate.ImageTranslator"
+
+    @blocking_import
+    def LegacyImageMap(self):
+        return "net.imagej.legacy.LegacyImageMap"
 
     # ImageJ-Ops Types
 


### PR DESCRIPTION
When we are running in `interactive` mode, it would be nice to have better support for original ImageJ plugins *when the ImageJ UI is not shown*. To that end, if ImageJ is enabled but the ImageJ UI is not visible, we can set the active `ImagePlus` to the active napari layer, to mimic the GUI components needed.

The current improvements allow you to call an *inplace*  `PlugIn` taking *one* input, and synchronize the output back into the active napari layer. 

There are, at time of writing, some open questions/bugs, that make this a draft PR:
1. The `Gaussian Blur...` command can cause napari-imagej to hang on shutdown. A stacktrace dump shows a non-daemon thread pool is still active, so it may be coming from [here](https://github.com/imagej/ImageJ/blob/eb49cce0d6513aa516fb09e7cdbaed3bf2e69731/ij/plugin/filter/GaussianBlur.java#L314)
2. We need to figure out how to close all of the relevant Java-side images when we perform something like this. How do we ensure that all created `ImageDisplay`s/`ImagePlus`es created through this code path are deleted after we're done? Otherwise, the created images can affect the execution of other ImageJ functionality?
3. How do we replicate this functionality for multiple input `ImagePlus`es? @ctrueden mentioned something about proxies, but I'm naive about this.

This would close #203 
