### PR TITLE
Add type hint for ImgPlus and capture ModuleCanceledEvent

### DIFF
--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -487,6 +487,10 @@ class JavaClasses(object):
         return "org.scijava.module.event.ModuleEvent"
 
     @blocking_import
+    def ModuleCanceledEvent(self):
+        return "org.scijava.module.event.ModuleCanceledEvent"
+
+    @blocking_import
     def ModuleExecutedEvent(self):
         return "org.scijava.module.event.ModuleExecutedEvent"
 

--- a/src/napari_imagej/types/type_hints.py
+++ b/src/napari_imagej/types/type_hints.py
@@ -122,8 +122,9 @@ def images() -> List[TypeHint]:
         TypeHint(
             jc.IterableInterval, "napari.layers.Image", priority=Priority.VERY_LOW
         ),
-        TypeHint(jc.Img, "napari.layers.Image"),
         TypeHint(jc.ImageDisplay, "napari.layers.Image"),
+        TypeHint(jc.Img, "napari.layers.Image"),
+        TypeHint(jc.ImgPlus, "napari.layers.Image"),
         TypeHint(jc.Dataset, "napari.layers.Image"),
         TypeHint(jc.DatasetView, "napari.layers.Image"),
         TypeHint(jc.ImagePlus, "napari.layers.Image"),

--- a/src/napari_imagej/utilities/progress_manager.py
+++ b/src/napari_imagej/utilities/progress_manager.py
@@ -33,9 +33,11 @@ class ModuleProgressManager:
     def update_progress(self, module: "jc.Module"):
         if pbr := self.prog_bars.get(module):
             pbr.update()
-            if pbr.total == pbr.n:
-                self.prog_bars.pop(module)
-                pbr.close()
+
+    def close(self, module: "jc.Module"):
+        if pbr := self.prog_bars.get(module):
+            self.prog_bars.pop(module)
+            pbr.close()
 
 
 pm = ModuleProgressManager()

--- a/src/napari_imagej/widgets/napari_imagej.py
+++ b/src/napari_imagej/widgets/napari_imagej.py
@@ -167,11 +167,15 @@ class NapariImageJWidget(QWidget):
         update Qt GUI elements from those threads.
         """
         module = event.getModule()
+        # Update progress if we see one of these
         if isinstance(
             event,
             (jc.ModuleExecutingEvent, jc.ModuleExecutedEvent, jc.ModuleFinishedEvent),
         ):
             pm.update_progress(module)
+        # Close progress if we see one of these
+        if isinstance(event, (jc.ModuleFinishedEvent, jc.ModuleCanceledEvent)):
+            pm.close(module)
 
 
 class WidgetFinalizer(QThread):

--- a/tests/utilities/test_progress.py
+++ b/tests/utilities/test_progress.py
@@ -23,6 +23,7 @@ def test_progress(ij, example_module):
     assert example_progress.n == 2
     pm.update_progress(example_module)
     assert example_progress.n == 3
+    pm.close(example_module)
     assert example_module not in pm.prog_bars
 
 
@@ -40,4 +41,20 @@ def test_progress_update_via_events(imagej_widget, ij, example_module, asserter)
 
     ij.event().publish(jc.ModuleFinishedEvent(example_module))
     asserter(lambda: pbr.n == 3)
+    asserter(lambda: example_module not in pm.prog_bars)
+
+
+def test_progress_cancel_via_events(imagej_widget, ij, example_module, asserter):
+    pm.init_progress(example_module)
+    asserter(lambda: example_module in pm.prog_bars)
+    pbr = pm.prog_bars[example_module]
+    asserter(lambda: pbr.n == 0)
+
+    ij.event().publish(jc.ModuleExecutingEvent(example_module))
+    asserter(lambda: pbr.n == 1)
+
+    ij.event().publish(jc.ModuleExecutedEvent(example_module))
+    asserter(lambda: pbr.n == 2)
+
+    ij.event().publish(jc.ModuleCanceledEvent(example_module))
     asserter(lambda: example_module not in pm.prog_bars)


### PR DESCRIPTION
@kephale brought up two different issues in #212, and throwing separation of concerns out the window I decided to solve both right here. This PR accomplishes two things:
1. Capture `ModuleCanceledEvent`s, and remove the progress bar when we cancel a module's execution.
2. Add a type hint for `ImgPlus` `ModuleItem`s, because otherwise napari-imagej thinks that it needs to ask the user for a `Labels` layer to get one of these.

@kephale can you try this out and let me know if it solves your BoneJ issue?