### PR TITLE
Capture and handle moduleerroredevent

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -41,4 +41,4 @@ then
   exitCode=$(cat exitCode.tmp)
   rm -f exitCode.tmp
 fi
-exit "$exitCode"
+exit $exitCode

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -32,7 +32,7 @@ minimum_versions = {
     "net.imagej:imagej-ops": "0.49.0",
     "net.imglib2:imglib2-unsafe": "1.0.0",
     "net.imglib2:imglib2-imglyb": "1.1.0",
-    "org.scijava:scijava-common": "2.91.0",
+    "org.scijava:scijava-common": "2.93.0",
     "org.scijava:scijava-search": "2.0.2",
     "sc.fiji:TrackMate": "7.11.0",
 }
@@ -214,6 +214,7 @@ class ImageJInitializer(QThread):
         add_legacy = settings["include_imagej_legacy"].get(bool)
         init_settings["add_legacy"] = add_legacy
 
+        # TEMP: Until imagej/napari-imagej#209 is solved.
         if add_legacy:
             config.endpoints.append("net.imagej:imagej-legacy:1.1.0")
 
@@ -487,6 +488,10 @@ class JavaClasses(object):
     @blocking_import
     def ModuleCanceledEvent(self):
         return "org.scijava.module.event.ModuleCanceledEvent"
+
+    @blocking_import
+    def ModuleErroredEvent(self):
+        return "org.scijava.module.event.ModuleErroredEvent"
 
     @blocking_import
     def ModuleExecutedEvent(self):

--- a/src/napari_imagej/utilities/events.py
+++ b/src/napari_imagej/utilities/events.py
@@ -1,0 +1,21 @@
+"""
+Helper functions for working with the SciJava event bus.
+"""
+
+
+def subscribe(ij, event_class, subscriber):
+    # NB: We need to retain a reference to this object or GC will delete it.
+    ij.object().addObject(subscriber)
+    _event_bus(ij).subscribe(event_class, subscriber)
+
+
+def subscribers(ij, event_class):
+    return _event_bus(ij).getSubscribers(event_class)
+
+
+def _event_bus(ij):
+    # HACK: Tap into the EventBus to obtain SciJava Module debug info.
+    # See https://github.com/scijava/scijava-common/issues/452
+    event_bus_field = ij.event().getClass().getDeclaredField("eventBus")
+    event_bus_field.setAccessible(True)
+    return event_bus_field.get(ij.event())

--- a/src/napari_imagej/utilities/logging.py
+++ b/src/napari_imagej/utilities/logging.py
@@ -6,9 +6,12 @@ Notable functions included in the module:
         - used for logging in a standardized way
 """
 import logging
+import os
 
 _logger = logging.getLogger(__name__)
-_logger.setLevel(logging.DEBUG)  # TEMP
+
+if os.environ.get("DEBUG", None):
+    _logger.setLevel(logging.DEBUG)
 
 
 # -- LOGGER API -- #
@@ -27,5 +30,8 @@ def log_debug(msg: str):
     Provides a debug message to the logger, prefaced by 'napari-imagej: '
     :param msg: The message to output
     """
-    debug_msg = "napari-imagej: " + msg
-    _logger.debug(debug_msg)
+    _logger.debug("napari-imagej: %s", msg)
+
+
+def is_debug():
+    return _logger.isEnabledFor(logging.DEBUG)

--- a/src/napari_imagej/utilities/progress_manager.py
+++ b/src/napari_imagej/utilities/progress_manager.py
@@ -35,8 +35,7 @@ class ModuleProgressManager:
             pbr.update()
 
     def close(self, module: "jc.Module"):
-        if pbr := self.prog_bars.get(module):
-            self.prog_bars.pop(module)
+        if pbr := self.prog_bars.pop(module, None):
             pbr.close()
 
 

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -19,6 +19,7 @@ from scyjava import is_arraylike
 from napari_imagej import settings
 from napari_imagej.java import ij, java_signals, jc
 from napari_imagej.resources import resource_path
+from napari_imagej.utilities.events import subscribe
 
 
 class NapariImageJMenu(QWidget):
@@ -60,16 +61,7 @@ class NapariImageJMenu(QWidget):
             self.gui_button.clicked.connect(show_ui)
 
         def post_init_setup():
-            # HACK: Tap into the EventBus to obtain SciJava Module debug info.
-            # See https://github.com/scijava/scijava-common/issues/452
-            event_bus_field = ij().event().getClass().getDeclaredField("eventBus")
-            event_bus_field.setAccessible(True)
-            event_bus = event_bus_field.get(ij().event())
-
-            subscriber = UIShownListener()
-            # NB We need to retain a reference to this object or GC will delete it
-            ij().object().addObject(subscriber)
-            event_bus.subscribe(jc.UIShownEvent.class_, subscriber)
+            subscribe(ij(), jc.UIShownEvent.class_, UIShownListener())
 
         java_signals.when_ij_ready(post_init_setup)
 

--- a/src/napari_imagej/widgets/napari_imagej.py
+++ b/src/napari_imagej/widgets/napari_imagej.py
@@ -17,7 +17,7 @@ from scyjava import when_jvm_stops
 from napari_imagej.java import ij, init_ij_async, java_signals, jc
 from napari_imagej.utilities._module_utils import _non_layer_widget
 from napari_imagej.utilities.events import subscribe
-from napari_imagej.utilities.logging import log_debug
+from napari_imagej.utilities.logging import is_debug, log_debug
 from napari_imagej.utilities.progress_manager import pm
 from napari_imagej.widgets.info_bar import InfoBox
 from napari_imagej.widgets.menu import NapariImageJMenu
@@ -253,8 +253,9 @@ class WidgetFinalizer(QThread):
         subscribe(ij(), jc.ModuleEvent.class_, progress_listener)
 
     def _finalize_exception_printer(self):
-        subscriber = NapariEventSubscriber()
-        subscribe(ij(), jc.SciJavaEvent.class_, subscriber)
+        if is_debug():
+            subscriber = NapariEventSubscriber()
+            subscribe(ij(), jc.SciJavaEvent.class_, subscriber)
 
 
 @JImplements(["org.scijava.event.EventSubscriber"], deferred=True)

--- a/src/napari_imagej/widgets/napari_imagej.py
+++ b/src/napari_imagej/widgets/napari_imagej.py
@@ -16,6 +16,7 @@ from scyjava import when_jvm_stops
 
 from napari_imagej.java import ij, init_ij_async, java_signals, jc
 from napari_imagej.utilities._module_utils import _non_layer_widget
+from napari_imagej.utilities.events import subscribe
 from napari_imagej.utilities.logging import log_debug
 from napari_imagej.utilities.progress_manager import pm
 from napari_imagej.widgets.info_bar import InfoBox
@@ -248,29 +249,12 @@ class WidgetFinalizer(QThread):
 
     def _finalize_info_bar(self):
         self.widget.info_box.version_bar.setText(f"ImageJ2 v{ij().getVersion()}")
-        # HACK: Tap into the EventBus to obtain SciJava Module debug info.
-        # See https://github.com/scijava/scijava-common/issues/452
-        event_bus_field = ij().event().getClass().getDeclaredField("eventBus")
-        event_bus_field.setAccessible(True)
-        event_bus = event_bus_field.get(ij().event())
-
         progress_listener = ProgressBarListener(self.widget.progress_handler)
-        # NB We need to retain a reference to this object or GC will delete it
-        ij().object().addObject(progress_listener)
-        # Subscribe to all ModuleEvents
-        event_bus.subscribe(jc.ModuleEvent.class_, progress_listener)
+        subscribe(ij(), jc.ModuleEvent.class_, progress_listener)
 
     def _finalize_exception_printer(self):
-        # HACK: Tap into the EventBus to obtain SciJava Module debug info.
-        # See https://github.com/scijava/scijava-common/issues/452
-        event_bus_field = ij().event().getClass().getDeclaredField("eventBus")
-        event_bus_field.setAccessible(True)
-        event_bus = event_bus_field.get(ij().event())
-
         subscriber = NapariEventSubscriber()
-        # NB We need to retain a reference to this object or GC will delete it
-        ij().object().addObject(subscriber)
-        event_bus.subscribe(jc.SciJavaEvent.class_, subscriber)
+        subscribe(ij(), jc.SciJavaEvent.class_, subscriber)
 
 
 @JImplements(["org.scijava.event.EventSubscriber"], deferred=True)

--- a/src/napari_imagej/widgets/napari_imagej.py
+++ b/src/napari_imagej/widgets/napari_imagej.py
@@ -174,8 +174,13 @@ class NapariImageJWidget(QWidget):
         ):
             pm.update_progress(module)
         # Close progress if we see one of these
-        if isinstance(event, (jc.ModuleFinishedEvent, jc.ModuleCanceledEvent)):
+        if isinstance(
+            event,
+            (jc.ModuleFinishedEvent, jc.ModuleCanceledEvent, jc.ModuleErroredEvent),
+        ):
             pm.close(module)
+        if isinstance(event, jc.ModuleErroredEvent):
+            raise event.getException()
 
 
 class WidgetFinalizer(QThread):

--- a/tests/utilities/test_progress.py
+++ b/tests/utilities/test_progress.py
@@ -1,8 +1,8 @@
 import pytest
 from napari.utils import progress
 
-from napari_imagej.java import jc
 from napari_imagej.utilities.progress_manager import pm
+from tests.utils import jc
 
 
 @pytest.fixture
@@ -58,3 +58,26 @@ def test_progress_cancel_via_events(imagej_widget, ij, example_module, asserter)
 
     ij.event().publish(jc.ModuleCanceledEvent(example_module))
     asserter(lambda: example_module not in pm.prog_bars)
+
+
+@pytest.mark.qt_no_exception_capture
+def test_progress_error_via_events(imagej_widget, ij, example_module, asserter, qtbot):
+    pm.init_progress(example_module)
+    asserter(lambda: example_module in pm.prog_bars)
+    pbr = pm.prog_bars[example_module]
+    asserter(lambda: pbr.n == 0)
+
+    ij.event().publish(jc.ModuleExecutingEvent(example_module))
+    asserter(lambda: pbr.n == 1)
+
+    ij.event().publish(jc.ModuleExecutedEvent(example_module))
+    asserter(lambda: pbr.n == 2)
+
+    with qtbot.capture_exceptions() as exceptions:
+        ij.event().publish(
+            jc.ModuleErroredEvent(example_module, jc.IllegalArgumentException("Yay"))
+        )
+        asserter(lambda: example_module not in pm.prog_bars)
+    assert len(exceptions) == 1
+    assert exceptions[0][0] == jc.IllegalArgumentException
+    assert exceptions[0][1].getMessage() == "Yay"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,6 +66,10 @@ class JavaClassesTest(JavaClasses):
         return "java.awt.Frame"
 
     @JavaClasses.blocking_import
+    def IllegalArgumentException(self):
+        return "java.lang.IllegalArgumentException"
+
+    @JavaClasses.blocking_import
     def ImageDisplay(self):
         return "net.imagej.display.ImageDisplay"
 

--- a/tests/widgets/test_menu.py
+++ b/tests/widgets/test_menu.py
@@ -17,6 +17,7 @@ from qtpy.QtWidgets import QApplication, QHBoxLayout, QMessageBox
 
 from napari_imagej import settings
 from napari_imagej.resources import resource_path
+from napari_imagej.utilities.events import subscribers
 from napari_imagej.widgets import menu
 from napari_imagej.widgets.menu import (
     FromIJButton,
@@ -524,17 +525,8 @@ def test_UIShownEvent_listener_registered(ij):
     """
     Ensure that a UI is registered to capture SciJavaEvents.
     """
-    # HACK: Tap into the EventBus to obtain SciJava Module debug info.
-    # See https://github.com/scijava/scijava-common/issues/452
-    event_bus_field = ij.event().getClass().getDeclaredField("eventBus")
-    event_bus_field.setAccessible(True)
-    event_bus = event_bus_field.get(ij.event())
-
-    subscribers = event_bus.getSubscribers(jc.UIShownEvent.class_)
-    for subscriber in subscribers:
-        if isinstance(subscriber, UIShownListener):
-            return True
-    return False
+    subs = subscribers(ij, jc.UIShownEvent.class_)
+    assert any(isinstance(sub, UIShownListener) for sub in subs)
 
 
 @pytest.fixture

--- a/tests/widgets/test_napari_imagej.py
+++ b/tests/widgets/test_napari_imagej.py
@@ -13,8 +13,8 @@ from napari_imagej.utilities.events import subscribers
 from napari_imagej.widgets.info_bar import InfoBox
 from napari_imagej.widgets.menu import NapariImageJMenu
 from napari_imagej.widgets.napari_imagej import (
-    NapariEventSubscriber,
     NapariImageJWidget,
+    ProgressBarListener,
     ResultRunner,
 )
 from napari_imagej.widgets.result_tree import SearchResultTree
@@ -264,7 +264,7 @@ def test_handle_output_non_layer(imagej_widget: NapariImageJWidget, asserter):
 
 def test_event_subscriber_registered(ij, imagej_widget: NapariImageJWidget, asserter):
     """
-    Ensure that a NapariEventSubscriber is registered to capture SciJavaEvents.
+    Ensure that a ProgressBarListener is registered to capture ModuleEvents.
     """
-    subs = subscribers(ij, jc.SciJavaEvent.class_)
-    assert any(isinstance(sub, NapariEventSubscriber) for sub in subs)
+    subs = subscribers(ij, jc.ModuleEvent.class_)
+    assert any(isinstance(sub, ProgressBarListener) for sub in subs)

--- a/tests/widgets/test_napari_imagej.py
+++ b/tests/widgets/test_napari_imagej.py
@@ -9,6 +9,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication, QPushButton, QVBoxLayout
 
 from napari_imagej.java import ij, jc
+from napari_imagej.utilities.events import subscribers
 from napari_imagej.widgets.info_bar import InfoBox
 from napari_imagej.widgets.menu import NapariImageJMenu
 from napari_imagej.widgets.napari_imagej import (
@@ -261,18 +262,9 @@ def test_handle_output_non_layer(imagej_widget: NapariImageJWidget, asserter):
     asserter(check_for_new_widget)
 
 
-def test_event_subscriber_registered(imagej_widget: NapariImageJWidget, asserter):
+def test_event_subscriber_registered(ij, imagej_widget: NapariImageJWidget, asserter):
     """
     Ensure that a NapariEventSubscriber is registered to capture SciJavaEvents.
     """
-    # HACK: Tap into the EventBus to obtain SciJava Module debug info.
-    # See https://github.com/scijava/scijava-common/issues/452
-    event_bus_field = ij().event().getClass().getDeclaredField("eventBus")
-    event_bus_field.setAccessible(True)
-    event_bus = event_bus_field.get(ij().event())
-
-    subscribers = event_bus.getSubscribers(jc.SciJavaEvent.class_)
-    for subscriber in subscribers:
-        if isinstance(subscriber, NapariEventSubscriber):
-            return True
-    return False
+    subs = subscribers(ij, jc.SciJavaEvent.class_)
+    assert any(isinstance(sub, NapariEventSubscriber) for sub in subs)


### PR DESCRIPTION
This PR handles cleanup related to module exception during execution.

TODO: Should we keep the test? Sometimes, the test results in hanging on my machine - is it worth the sanity checking of making sure that `ModuleErroredEvent` is correctly handled? Might need to dig further.