### PR TITLE
Set a higher maximum for new output images

### DIFF
--- a/src/napari_imagej/widgets/parameter_widgets.py
+++ b/src/napari_imagej/widgets/parameter_widgets.py
@@ -190,7 +190,10 @@ class MutableOutputWidget(Container):
             shape=dict(
                 annotation=List[int],
                 value=self._default_new_shape(),
-                options=dict(tooltip="By default, the shape of the first Layer input"),
+                options=dict(
+                    tooltip="By default, the shape of the first Layer input",
+                    options=dict(min=0, max=2**31 - 10),
+                ),
             ),
             array_type=dict(
                 annotation=str,


### PR DESCRIPTION
This PR enables you to define image sizes outside of the standard magicgui dimension sizes `[0, 999]`. Now, you can define image dimensions of size `[0, (2^31)-10]`.

TODO: What do we do if the user wants to make an output image that is larger than that? We will get the same error if the user has an active image with dimension larger than that, and tries to create a new output.