### PR TITLE
Use a modal dialog to display Java-side errors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,6 @@ from typing import Callable, Generator
 
 import pytest
 from napari import Viewer
-from qtpy.QtCore import QRunnable, Qt, QThreadPool
-from qtpy.QtWidgets import QApplication, QMessageBox
 
 from napari_imagej import settings
 from napari_imagej.java import init_ij
@@ -127,51 +125,3 @@ def gui_widget_chooser(viewer) -> Generator[NapariImageJMenu, None, None]:
 
     # Cleanup -> Close the widget, trigger ImageJ shutdown
     widget.close()
-
-
-@pytest.fixture()
-def popup_handler(asserter) -> Callable[[str, Callable[[], None]], None]:
-    """Fixture used to handle RichTextPopups"""
-
-    def handle_popup(
-        text: str, is_rich: bool, button, popup_generator: Callable[[], None]
-    ):
-        # # Start the handler in a new thread
-        class Handler(QRunnable):
-            # Test popup when running headlessly
-            def run(self) -> None:
-                asserter(lambda: isinstance(QApplication.activeWindow(), QMessageBox))
-                msg = QApplication.activeWindow()
-                if text != msg.text():
-                    print("Text differed")
-                    print(text)
-                    print(msg.text())
-                    self._passed = False
-                    return
-                if is_rich and Qt.RichText != msg.textFormat():
-                    print("Not rich text")
-                    self._passed = False
-                    return
-                if is_rich and Qt.TextBrowserInteraction != msg.textInteractionFlags():
-                    print("No browser interaction")
-                    self._passed = False
-                    return
-
-                ok_button = msg.button(button)
-                ok_button.clicked.emit()
-                asserter(lambda: QApplication.activeModalWidget() is not msg)
-                self._passed = True
-
-            def passed(self) -> bool:
-                return self._passed
-
-        runnable = Handler()
-        QThreadPool.globalInstance().start(runnable)
-
-        # Click the button
-        popup_generator()
-        # Wait for the popup to be handled
-        asserter(QThreadPool.globalInstance().waitForDone)
-        assert runnable.passed()
-
-    return handle_popup

--- a/tests/utilities/test_progress.py
+++ b/tests/utilities/test_progress.py
@@ -61,9 +61,7 @@ def test_progress_cancel_via_events(imagej_widget, ij, example_module, asserter)
     asserter(lambda: example_module not in pm.prog_bars)
 
 
-def test_progress_error_via_events(
-    imagej_widget, ij, example_module, asserter, qtbot, popup_handler
-):
+def test_progress_error_via_events(imagej_widget, ij, example_module, asserter, qtbot):
     pm.init_progress(example_module)
     asserter(lambda: example_module in pm.prog_bars)
     pbr = pm.prog_bars[example_module]


### PR DESCRIPTION
napari's error dialog is lacking and buggy, as described in #234. So we will pop a modal dialog displaying any Java-side errors now.