### PR TITLE
Append module name to uninformative output names

### DIFF
--- a/src/napari_imagej/utilities/_module_utils.py
+++ b/src/napari_imagej/utilities/_module_utils.py
@@ -234,11 +234,14 @@ def _modify_function_signature(
 
 def _devise_layer_name(info: "jc.ModuleInfo", original_name: str) -> str:
     """Utility function to overwrite uninformative output names"""
-    # Common ImageJ result names
-    if original_name.lower() in ["out", "output", "result"]:
-        return f"{original_name} [{info.getTitle()}]"
-    # Baseline layer names
+
+    # Common names should append module info for context.
     if original_name.lower() in [
+        # Common ImageJ result names
+        "out",
+        "output",
+        "result",
+        # Baseline layer names
         "image",
         "labels",
         "shapes",
@@ -247,6 +250,7 @@ def _devise_layer_name(info: "jc.ModuleInfo", original_name: str) -> str:
         "tracks",
     ]:
         return f"{original_name} [{info.getTitle()}]"
+    # Otherwise, the name is probably sufficiently informative.
     return original_name
 
 

--- a/src/napari_imagej/utilities/_module_utils.py
+++ b/src/napari_imagej/utilities/_module_utils.py
@@ -232,6 +232,24 @@ def _modify_function_signature(
     function.__signature__ = sig.replace(parameters=all_params)
 
 
+def _devise_layer_name(info: "jc.ModuleInfo", original_name: str) -> str:
+    """Utility function to overwrite uninformative output names"""
+    # Common ImageJ result names
+    if original_name.lower() in ["out", "output", "result"]:
+        return f"{original_name} [{info.getTitle()}]"
+    # Baseline layer names
+    if original_name.lower() in [
+        "image",
+        "labels",
+        "shapes",
+        "surface",
+        "points",
+        "tracks",
+    ]:
+        return f"{original_name} [{info.getTitle()}]"
+    return original_name
+
+
 def _pure_module_outputs(
     module: "jc.Module",
     user_inputs: List["jc.ModuleItem"],
@@ -245,6 +263,7 @@ def _pure_module_outputs(
     widget_outputs = []
 
     # Partition outputs into layer and widget outputs
+    info = module.getInfo()
     outputs = module.getOutputs()
     for output_entry in outputs.entrySet():
         # Ignore None outputs
@@ -257,13 +276,18 @@ def _pure_module_outputs(
         if is_arraylike(output) or isinstance(output, Layer):
             # If the layer was also an input, it came from a napari layer. We
             # don't want duplicate layers, so skip this one.
-            if module.getInfo().getInput(name) in user_inputs and module.getInput(name):
+            if info.getInput(name) in user_inputs and module.getInput(name):
                 continue
-            # Convert layer data into a layer
+            # Convert arraylikes into a Layer
             if is_arraylike(output):
                 output = Layer.create(
-                    data=output, meta={"name": name}, layer_type="image"
+                    data=output,
+                    meta={"name": _devise_layer_name(info, name)},
+                    layer_type="image",
                 )
+            # Rename Layers
+            elif isinstance(output, Layer):
+                output.name = _devise_layer_name(info, output.name)
             # Add the layer to the layer output list
             layer_outputs.append(output)
         # Otherwise, this output needs to go in a widget

--- a/tests/utilities/test_module_utils.py
+++ b/tests/utilities/test_module_utils.py
@@ -681,6 +681,7 @@ def test_info_for(ij):
 def test_devise_layer_name():
     info = DummyModuleInfo()
 
+    # Test "uninformative" names are given Module context
     overwritten_names = [
         "out",
         "output",
@@ -692,9 +693,12 @@ def test_devise_layer_name():
         "Surface",
         "Tracks",
     ]
-
     for name in overwritten_names:
         assert (
             _module_utils._devise_layer_name(info, name)
             == f"{name} [Dummy Module Info]"
         )
+
+    # Test "informative" names are left alone
+    informative_name = "foo"
+    assert informative_name == _module_utils._devise_layer_name(info, informative_name)

--- a/tests/utilities/test_module_utils.py
+++ b/tests/utilities/test_module_utils.py
@@ -17,7 +17,7 @@ from pandas import DataFrame
 from napari_imagej.types.type_hints import type_hints
 from napari_imagej.types.type_utils import _napari_layer_types
 from napari_imagej.utilities import _module_utils
-from tests.utils import DummyModuleItem, jc
+from tests.utils import DummyModuleInfo, DummyModuleItem, jc
 
 
 @pytest.fixture
@@ -676,3 +676,25 @@ def test_info_for(ij):
     # Case 3: A ClassSearchResult (no info)
     result = jc.ClassSearchResult(jc.Double, "")
     assert _module_utils.info_for(result) is None
+
+
+def test_devise_layer_name():
+    info = DummyModuleInfo()
+
+    overwritten_names = [
+        "out",
+        "output",
+        "result",
+        "Image",
+        "Labels",
+        "Shapes",
+        "Points",
+        "Surface",
+        "Tracks",
+    ]
+
+    for name in overwritten_names:
+        assert (
+            _module_utils._devise_layer_name(info, name)
+            == f"{name} [Dummy Module Info]"
+        )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -184,9 +184,13 @@ class DummyModuleInfo:
     Fields can and should be added as needed for tests.
     """
 
-    def __init__(self, inputs=[], outputs=[]):
+    def __init__(self, title="Dummy Module Info", inputs=[], outputs=[]):
+        self._title = title
         self._inputs = inputs
         self._outputs = outputs
+
+    def getTitle(self):
+        return self._title
 
     def outputs(self):
         return self._outputs


### PR DESCRIPTION
`Module` result names like `out`, `output` and `result` are uninformative, and so are the basic napari layer names (`Image`, `Labels`, ...). This PR overwrites them to generate more helpful names.

Currently, a "more helpful name" is the original name, with the module name appended afterwards. We can change that, though, if someone else has a better idea.