### PR TITLE
confuse: avoid reading in constructor

### DIFF
--- a/src/napari_imagej/settings.py
+++ b/src/napari_imagej/settings.py
@@ -236,7 +236,7 @@ def _confuse_config() -> confuse.Configuration:
     Construct a confuse configuration object.
     https://confuse.readthedocs.io/
     """
-    return confuse.Configuration("napari-imagej")
+    return confuse.Configuration("napari-imagej", read=False)
 
 
 def _confuse_get(config: confuse.Configuration, name, default_value) -> Any:


### PR DESCRIPTION
If we do not pass `read=False` in the constructor, then confuse will by default read the user's configured files. Since we are reading anyways in `load()`, we might as well just pass `read=False` every time within `_confuse_config`.

Closes #245