### PR TITLE
Assign reasonable axis defaults from napari Image layers

### DIFF
--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -622,8 +622,16 @@ class JavaClasses(object):
         return "net.imagej.display.DatasetView"
 
     @blocking_import
+    def DefaultLinearAxis(self):
+        return "net.imagej.axis.DefaultLinearAxis"
+
+    @blocking_import
     def DefaultROITree(self):
         return "net.imagej.roi.DefaultROITree"
+
+    @blocking_import
+    def EnumeratedAxis(self):
+        return "net.imagej.axis.EnumeratedAxis"
 
     @blocking_import
     def ImageDisplay(self):

--- a/tests/utilities/test_module_utils.py
+++ b/tests/utilities/test_module_utils.py
@@ -460,6 +460,19 @@ script_both_but_required: str = """
 from net.imglib2.img.array import ArrayImgs
 """
 
+script_list_of_outputs: str = """
+#@output java.util.List imgList
+#@output java.util.List varList
+
+from net.imglib2.img.array import ArrayImgs
+a = ArrayImgs.unsignedBytes(10, 10)
+b = ArrayImgs.unsignedBytes(10, 10)
+
+from java.util import Arrays
+imgList = Arrays.asList(a, b)
+varList = Arrays.asList(1.0, 2.0)
+"""
+
 widget_parameterizations = [
     (script_zero_layer_zero_widget, 0, 0, []),
     (script_one_layer_zero_widget, 1, 0, []),
@@ -474,6 +487,7 @@ widget_parameterizations = [
     (script_both_but_required, 0, 0, [numpy.zeros((10, 10), dtype=numpy.int8)]),
     # One layer returned as we create the optional input internally
     (script_both_but_optional, 1, 0, [None]),
+    (script_list_of_outputs, 2, 1, [None]),
 ]
 
 


### PR DESCRIPTION
Lots of situations (the ImageJ2 UI, BoneJ Ops, etc.) expect that images have well-defined axis metadata (including Axis scales, units, types, etc.). napari doesn't yet have a lot of that metadata, but we can assign some reasonable defaults in the meantime.