### PR TITLE
Add a REPL widget that supports the SciJava ScriptREPL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
           # Create env with dev packages
           auto-update-conda: true
           python-version: "3.10"
-          miniforge-variant: Mambaforge
+          miniforge-version: latest
           environment-file: dev-environment.yml
           # Activate napari-imagej-dev environment
           activate-environment: napari-imagej-dev

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -6,7 +6,7 @@ cd "$dir/.."
 modes="
 | Testing ImageJ2 + original ImageJ |NAPARI_IMAGEJ_INCLUDE_IMAGEJ_LEGACY=TRUE
 |    Testing ImageJ2 standalone     |NAPARI_IMAGEJ_INCLUDE_IMAGEJ_LEGACY=FALSE
-|  Testing Fiji Is Just ImageJ(2)   |NAPARI_IMAGEJ_IMAGEJ_DIRECTORY_OR_ENDPOINT=sc.fiji:fiji:2.13.1
+|  Testing Fiji Is Just ImageJ(2)   |NAPARI_IMAGEJ_IMAGEJ_DIRECTORY_OR_ENDPOINT=sc.fiji:fiji:2.15.0
 "
 
 echo "$modes" | while read mode

--- a/doc/Configuration.rst
+++ b/doc/Configuration.rst
@@ -95,6 +95,15 @@ One common use case for this feature is to increase the maximum heap space avail
 
     Specifying 32GB of memory available to ImageJ ecosystem routines in the JVM.
 
+Using the SciJava REPL
+--------------------------------
+
+You can use the SciJava REPL to interactively run SciJava code. This makes it possible to do things like paste existing SciJava scripts into the REPL. More information on scripting in SciJava can be found `here <https://imagej.net/scripting/>`_.
+
+.. figure:: https://media.imagej.net/napari-imagej/scijava_repl.png
+    
+    The REPL can be shown/hidden by clicking on the command prompt icon.
+    
 
 .. _Fiji: https://imagej.net/software/fiji/
 .. _ImageJ2: https://imagej.net/software/imagej2/

--- a/doc/Configuration.rst
+++ b/doc/Configuration.rst
@@ -95,15 +95,6 @@ One common use case for this feature is to increase the maximum heap space avail
 
     Specifying 32GB of memory available to ImageJ ecosystem routines in the JVM.
 
-Using the SciJava REPL
---------------------------------
-
-You can use the SciJava REPL to interactively run SciJava code. This makes it possible to do things like paste existing SciJava scripts into the REPL. More information on scripting in SciJava can be found `here <https://imagej.net/scripting/>`_.
-
-.. figure:: https://media.imagej.net/napari-imagej/scijava_repl.png
-    
-    The REPL can be shown/hidden by clicking on the command prompt icon.
-    
 
 .. _Fiji: https://imagej.net/software/fiji/
 .. _ImageJ2: https://imagej.net/software/imagej2/

--- a/doc/Usage.rst
+++ b/doc/Usage.rst
@@ -63,7 +63,7 @@ Using the SciJava REPL
 
 You can use the SciJava REPL to interactively run SciJava code. This makes it possible to do things like paste existing SciJava scripts into the REPL. More information on scripting in SciJava can be found `here <https://imagej.net/scripting/interpreter>`_.
 
-.. figure:: https://media.imagej.net/napari-imagej/scijava_repl.png
+.. figure:: https://media.imagej.net/napari-imagej/0.2.0/script_repl.png
     
     The REPL can be shown/hidden by clicking on the command prompt icon.
     

--- a/doc/Usage.rst
+++ b/doc/Usage.rst
@@ -57,3 +57,13 @@ Note that these buttons are only enabled when there is a ``Layer`` that can be t
     Using the |advanced export| button, users can provide metadata for richer data transfer to the ImageJ UI
 
 The |import| button can be used to transfer the **active** ImageJ window back into the napari application.
+
+Using the SciJava REPL
+--------------------------------
+
+You can use the SciJava REPL to interactively run SciJava code. This makes it possible to do things like paste existing SciJava scripts into the REPL. More information on scripting in SciJava can be found `here <https://imagej.net/scripting/interpreter>`_.
+
+.. figure:: https://media.imagej.net/napari-imagej/scijava_repl.png
+    
+    The REPL can be shown/hidden by clicking on the command prompt icon.
+    

--- a/src/napari_imagej/__init__.py
+++ b/src/napari_imagej/__init__.py
@@ -20,5 +20,9 @@ https://pyimagej.readthedocs.io/en/latest/
 
 import scyjava as sj
 
+from napari_imagej.model import NapariImageJ
+
 __author__ = "ImageJ2 developers"
 __version__ = sj.get_version("napari-imagej")
+
+nij = NapariImageJ()

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -152,7 +152,6 @@ def _optional_requirements(ij: "jc.ImageJ"):
 
 
 class NijJavaClasses(JavaClasses):
-
     # Java Primitives
 
     @JavaClasses.java_import
@@ -352,6 +351,10 @@ class NijJavaClasses(JavaClasses):
     @JavaClasses.java_import
     def ScriptREPL(self):
         return "org.scijava.script.ScriptREPL"
+
+    @JavaClasses.java_import
+    def ScriptService(self):
+        return "org.scijava.script.ScriptService"
 
     @JavaClasses.java_import
     def Searcher(self):

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -288,7 +288,7 @@ class JavaClasses(object):
 
     @blocking_import
     def ByteArrayOutputStream(self):
-        return "java.io.ByteArrayOutputStream"
+        "java.io.ByteArrayOutputStream"
 
     @blocking_import
     def Date(self):
@@ -387,6 +387,10 @@ class JavaClasses(object):
     @blocking_import
     def SciJavaEvent(self):
         return "org.scijava.event.SciJavaEvent"
+
+    @blocking_import
+    def ScriptREPL(self):
+        return "org.scijava.script.ScriptREPL"
 
     @blocking_import
     def Searcher(self):

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -314,6 +314,10 @@ class JavaClasses(object):
     def Window(self):
         return "java.awt.Window"
 
+    @blocking_import
+    def ScriptException(self):
+        return "javax.script.ScriptException"
+
     # SciJava Types
 
     @blocking_import

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -12,11 +12,10 @@ Notable fields included in the module:
         - object whose fields are lazily-loaded Java Class instances.
 """
 
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 
 import imagej
-from jpype import JClass
-from scyjava import config, get_version, is_version_at_least, jimport, jvm_started
+from scyjava import config, get_version, is_version_at_least, jimport, JavaClasses
 
 from napari_imagej import settings
 from napari_imagej.utilities.logging import log_debug
@@ -169,539 +168,521 @@ def _optional_requirements():
     return optionals
 
 
-class JavaClasses(object):
-    def blocking_import(func: Callable[[], str]) -> Callable[[], JClass]:
-        """
-        A decorator used to lazily evaluate a java import.
-        func is a function of a Python class that takes no arguments and
-        returns a string identifying a Java class by name.
-
-        Using that function, this decorator creates a property
-        that when called:
-        * Blocks until the ImageJ gateway has been created
-        * Imports the class identified by the function
-        """
-
-        @property
-        def inner(self):
-            if not jvm_started():
-                raise Exception()
-            try:
-                return jimport(func(self))
-            except TypeError:
-                return None
-
-        return inner
+class NijJavaClasses(JavaClasses):
 
     # Java Primitives
 
-    @blocking_import
+    @JavaClasses.java_import
     def Boolean(self):
         return "java.lang.Boolean"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Byte(self):
         return "java.lang.Byte"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Class(self):
         return "java.lang.Class"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Character(self):
         return "java.lang.Character"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Double(self):
         return "java.lang.Double"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Float(self):
         return "java.lang.Float"
 
-    @blocking_import
+    @JavaClasses.java_import
+    def ImageJ(self):
+        return "net.imagej.ImageJ"
+
+    @JavaClasses.java_import
     def Integer(self):
         return "java.lang.Integer"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Long(self):
         return "java.lang.Long"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Number(self):
         return "java.lang.Number"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Short(self):
         return "java.lang.Short"
 
-    @blocking_import
+    @JavaClasses.java_import
     def String(self):
         return "java.lang.String"
 
     # Java Array Primitives
 
-    @blocking_import
+    @JavaClasses.java_import
     def Boolean_Arr(self):
         return "[Z"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Byte_Arr(self):
         return "[B"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Character_Arr(self):
         return "[C"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Double_Arr(self):
         return "[D"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Float_Arr(self):
         return "[F"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Integer_Arr(self):
         return "[I"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Long_Arr(self):
         return "[J"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Short_Arr(self):
         return "[S"
 
     # Vanilla Java Classes
 
-    @blocking_import
+    @JavaClasses.java_import
     def ArrayList(self):
         return "java.util.ArrayList"
 
-    @blocking_import
+    @JavaClasses.java_import
     def BigDecimal(self):
         return "java.math.BigDecimal"
 
-    @blocking_import
+    @JavaClasses.java_import
     def BigInteger(self):
         return "java.math.BigInteger"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ByteArrayOutputStream(self):
         "java.io.ByteArrayOutputStream"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Date(self):
         return "java.util.Date"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Enum(self):
         return "java.lang.Enum"
 
-    @blocking_import
+    @JavaClasses.java_import
     def File(self):
         return "java.io.File"
 
-    @blocking_import
+    @JavaClasses.java_import
     def HashMap(self):
         return "java.util.HashMap"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Path(self):
         return "java.nio.file.Path"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Window(self):
         return "java.awt.Window"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ScriptException(self):
         return "javax.script.ScriptException"
 
     # SciJava Types
 
-    @blocking_import
+    @JavaClasses.java_import
     def DisplayPostprocessor(self):
         return "org.scijava.display.DisplayPostprocessor"
 
-    @blocking_import
+    @JavaClasses.java_import
     def FileWidget(self):
         return "org.scijava.widget.FileWidget"
 
-    @blocking_import
+    @JavaClasses.java_import
     def InputHarvester(self):
         return "org.scijava.widget.InputHarvester"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Module(self):
         return "org.scijava.module.Module"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ModuleEvent(self):
         return "org.scijava.module.event.ModuleEvent"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ModuleCanceledEvent(self):
         return "org.scijava.module.event.ModuleCanceledEvent"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ModuleErroredEvent(self):
         return "org.scijava.module.event.ModuleErroredEvent"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ModuleExecutedEvent(self):
         return "org.scijava.module.event.ModuleExecutedEvent"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ModuleExecutingEvent(self):
         return "org.scijava.module.event.ModuleExecutingEvent"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ModuleFinishedEvent(self):
         return "org.scijava.module.event.ModuleFinishedEvent"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ModuleInfo(self):
         return "org.scijava.module.ModuleInfo"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ModuleItem(self):
         return "org.scijava.module.ModuleItem"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ModuleStartedEvent(self):
         return "org.scijava.module.event.ModuleStartedEvent"
 
-    @blocking_import
+    @JavaClasses.java_import
     def PostprocessorPlugin(self):
         return "org.scijava.module.process.PostprocessorPlugin"
 
-    @blocking_import
+    @JavaClasses.java_import
     def PreprocessorPlugin(self):
         return "org.scijava.module.process.PreprocessorPlugin"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ResultsPostprocessor(self):
         return "org.scijava.table.process.ResultsPostprocessor"
 
-    @blocking_import
+    @JavaClasses.java_import
     def SciJavaEvent(self):
         return "org.scijava.event.SciJavaEvent"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ScriptREPL(self):
         return "org.scijava.script.ScriptREPL"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Searcher(self):
         return "org.scijava.search.Searcher"
 
-    @blocking_import
+    @JavaClasses.java_import
     def SearchEvent(self):
         return "org.scijava.search.SearchEvent"
 
-    @blocking_import
+    @JavaClasses.java_import
     def SearchListener(self):
         return "org.scijava.search.SearchListener"
 
-    @blocking_import
+    @JavaClasses.java_import
     def SearchResult(self):
         return "org.scijava.search.SearchResult"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Table(self):
         return "org.scijava.table.Table"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Types(self):
         return "org.scijava.util.Types"
 
-    @blocking_import
+    @JavaClasses.java_import
     def UIComponent(self):
         return "org.scijava.widget.UIComponent"
 
-    @blocking_import
+    @JavaClasses.java_import
     def UIShownEvent(self):
         return "org.scijava.ui.event.UIShownEvent"
 
-    @blocking_import
+    @JavaClasses.java_import
     def UserInterface(self):
         return "org.scijava.ui.UserInterface"
 
     # ImageJ Legacy Types
 
-    @blocking_import
+    @JavaClasses.java_import
     def LegacyCommandInfo(self):
         return "net.imagej.legacy.command.LegacyCommandInfo"
 
     # ImgLib2 Types
 
-    @blocking_import
+    @JavaClasses.java_import
     def BitType(self):
         return "net.imglib2.type.logic.BitType"
 
-    @blocking_import
+    @JavaClasses.java_import
     def BooleanType(self):
         return "net.imglib2.type.BooleanType"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ColorTable(self):
         return "net.imglib2.display.ColorTable"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ColorTable8(self):
         return "net.imglib2.display.ColorTable8"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ColorTables(self):
         return "net.imagej.display.ColorTables"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ComplexType(self):
         return "net.imglib2.type.numeric.ComplexType"
 
-    @blocking_import
+    @JavaClasses.java_import
     def DoubleType(self):
         return "net.imglib2.type.numeric.real.DoubleType"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Img(self):
         return "net.imglib2.img.Img"
 
-    @blocking_import
+    @JavaClasses.java_import
     def IntegerType(self):
         return "net.imglib2.type.numeric.IntegerType"
 
-    @blocking_import
+    @JavaClasses.java_import
     def IterableInterval(self):
         return "net.imglib2.IterableInterval"
 
-    @blocking_import
+    @JavaClasses.java_import
     def LongType(self):
         return "net.imglib2.type.numeric.integer.LongType"
 
-    @blocking_import
+    @JavaClasses.java_import
     def NumericType(self):
         return "net.imglib2.type.numeric.NumericType"
 
-    @blocking_import
+    @JavaClasses.java_import
     def OutOfBoundsFactory(self):
         return "net.imglib2.outofbounds.OutOfBoundsFactory"
 
-    @blocking_import
+    @JavaClasses.java_import
     def OutOfBoundsBorderFactory(self):
         return "net.imglib2.outofbounds.OutOfBoundsBorderFactory"
 
-    @blocking_import
+    @JavaClasses.java_import
     def OutOfBoundsMirrorExpWindowingFactory(self):
         return "net.imglib2.outofbounds.OutOfBoundsMirrorExpWindowingFactory"
 
-    @blocking_import
+    @JavaClasses.java_import
     def OutOfBoundsMirrorFactory(self):
         return "net.imglib2.outofbounds.OutOfBoundsMirrorFactory"
 
-    @blocking_import
+    @JavaClasses.java_import
     def OutOfBoundsPeriodicFactory(self):
         return "net.imglib2.outofbounds.OutOfBoundsPeriodicFactory"
 
-    @blocking_import
+    @JavaClasses.java_import
     def OutOfBoundsRandomValueFactory(self):
         return "net.imglib2.outofbounds.OutOfBoundsRandomValueFactory"
 
-    @blocking_import
+    @JavaClasses.java_import
     def RandomAccessible(self):
         return "net.imglib2.RandomAccessible"
 
-    @blocking_import
+    @JavaClasses.java_import
     def RandomAccessibleInterval(self):
         return "net.imglib2.RandomAccessibleInterval"
 
-    @blocking_import
+    @JavaClasses.java_import
     def RealPoint(self):
         return "net.imglib2.RealPoint"
 
-    @blocking_import
+    @JavaClasses.java_import
     def RealType(self):
         return "net.imglib2.type.numeric.RealType"
 
     # ImgLib2-algorithm Types
 
-    @blocking_import
+    @JavaClasses.java_import
     def CenteredRectangleShape(self):
         return "net.imglib2.algorithm.neighborhood.CenteredRectangleShape"
 
-    @blocking_import
+    @JavaClasses.java_import
     def DiamondShape(self):
         return "net.imglib2.algorithm.neighborhood.DiamondShape"
 
-    @blocking_import
+    @JavaClasses.java_import
     def DiamondTipsShape(self):
         return "net.imglib2.algorithm.neighborhood.DiamondTipsShape"
 
-    @blocking_import
+    @JavaClasses.java_import
     def HorizontalLineShape(self):
         return "net.imglib2.algorithm.neighborhood.HorizontalLineShape"
 
-    @blocking_import
+    @JavaClasses.java_import
     def HyperSphereShape(self):
         return "net.imglib2.algorithm.neighborhood.HyperSphereShape"
 
-    @blocking_import
+    @JavaClasses.java_import
     def PairOfPointsShape(self):
         return "net.imglib2.algorithm.neighborhood.PairOfPointsShape"
 
-    @blocking_import
+    @JavaClasses.java_import
     def PeriodicLineShape(self):
         return "net.imglib2.algorithm.neighborhood.PeriodicLineShape"
 
-    @blocking_import
+    @JavaClasses.java_import
     def RectangleShape(self):
         return "net.imglib2.algorithm.neighborhood.RectangleShape"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Shape(self):
         return "net.imglib2.algorithm.neighborhood.Shape"
 
     # ImgLib2-roi Types
 
-    @blocking_import
+    @JavaClasses.java_import
     def Box(self):
         return "net.imglib2.roi.geom.real.Box"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ClosedWritableBox(self):
         return "net.imglib2.roi.geom.real.ClosedWritableBox"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ClosedWritableEllipsoid(self):
         return "net.imglib2.roi.geom.real.ClosedWritableEllipsoid"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ClosedWritablePolygon2D(self):
         return "net.imglib2.roi.geom.real.ClosedWritablePolygon2D"
 
-    @blocking_import
+    @JavaClasses.java_import
     def DefaultWritableLine(self):
         return "net.imglib2.roi.geom.real.DefaultWritableLine"
 
-    @blocking_import
+    @JavaClasses.java_import
     def DefaultWritablePolyline(self):
         return "net.imglib2.roi.geom.real.DefaultWritablePolyline"
 
-    @blocking_import
+    @JavaClasses.java_import
     def DefaultWritableRealPointCollection(self):
         return "net.imglib2.roi.geom.real.DefaultWritableRealPointCollection"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ImgLabeling(self):
         return "net.imglib2.roi.labeling.ImgLabeling"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Line(self):
         return "net.imglib2.roi.geom.real.Line"
 
-    @blocking_import
+    @JavaClasses.java_import
     def PointMask(self):
         return "net.imglib2.roi.geom.real.PointMask"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Polygon2D(self):
         return "net.imglib2.roi.geom.real.Polygon2D"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Polyline(self):
         return "net.imglib2.roi.geom.real.Polyline"
 
-    @blocking_import
+    @JavaClasses.java_import
     def RealPointCollection(self):
         return "net.imglib2.roi.geom.real.RealPointCollection"
 
-    @blocking_import
+    @JavaClasses.java_import
     def SuperEllipsoid(self):
         return "net.imglib2.roi.geom.real.SuperEllipsoid"
 
     # ImageJ2 Types
 
-    @blocking_import
+    @JavaClasses.java_import
     def Axes(self):
         return "net.imagej.axis.Axes"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Dataset(self):
         return "net.imagej.Dataset"
 
-    @blocking_import
+    @JavaClasses.java_import
     def DatasetView(self):
         return "net.imagej.display.DatasetView"
 
-    @blocking_import
+    @JavaClasses.java_import
     def DefaultLinearAxis(self):
         return "net.imagej.axis.DefaultLinearAxis"
 
-    @blocking_import
+    @JavaClasses.java_import
     def DefaultROITree(self):
         return "net.imagej.roi.DefaultROITree"
 
-    @blocking_import
+    @JavaClasses.java_import
     def EnumeratedAxis(self):
         return "net.imagej.axis.EnumeratedAxis"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ImageDisplay(self):
         return "net.imagej.display.ImageDisplay"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ImgPlus(self):
         return "net.imagej.ImgPlus"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Mesh(self):
         return "net.imagej.mesh.Mesh"
 
-    @blocking_import
+    @JavaClasses.java_import
     def NaiveDoubleMesh(self):
         return "net.imagej.mesh.naive.NaiveDoubleMesh"
 
-    @blocking_import
+    @JavaClasses.java_import
     def ROITree(self):
         return "net.imagej.roi.ROITree"
 
     # ImageJ Types
 
-    @blocking_import
+    @JavaClasses.java_import
     def ImagePlus(self):
         return "ij.ImagePlus"
 
-    @blocking_import
+    @JavaClasses.java_import
     def Roi(self):
         return "ij.gui.Roi"
 
     # ImageJ-Legacy Types
 
-    @blocking_import
+    @JavaClasses.java_import
     def IJRoiWrapper(self):
         return "net.imagej.legacy.convert.roi.IJRoiWrapper"
 
     # ImageJ-Ops Types
 
-    @blocking_import
+    @JavaClasses.java_import
     def Initializable(self):
         return "net.imagej.ops.Initializable"
 
-    @blocking_import
+    @JavaClasses.java_import
     def OpInfo(self):
         return "net.imagej.ops.OpInfo"
 
-    @blocking_import
+    @JavaClasses.java_import
     def OpSearcher(self):
         return "net.imagej.ops.search.OpSearcher"
 
     # Scifio-Labeling Types
 
-    @blocking_import
+    @JavaClasses.java_import
     def LabelingIOService(self):
         return "io.scif.labeling.LabelingIOService"
 
 
-jc = JavaClasses()
+jc = NijJavaClasses()

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -21,7 +21,7 @@ from scyjava import config, get_version, is_version_at_least, jimport, jvm_start
 from napari_imagej import settings
 from napari_imagej.utilities.logging import log_debug
 
-# -- Constants --
+# -- Constants -- #
 
 minimum_versions = {
     "io.scif:scifio": "0.45.0",
@@ -39,7 +39,6 @@ minimum_versions = {
 
 _ij = None
 
-
 def ij():
     if _ij is None:
         raise Exception(
@@ -47,10 +46,11 @@ def ij():
         )
     return _ij
 
+# -- Public functions -- #
 
 def init_ij() -> "jc.ImageJ":
     """
-    Creates the ImageJ instance
+    Create an ImageJ2 gateway.
     """
     global _ij
     if _ij:
@@ -87,10 +87,11 @@ def init_ij() -> "jc.ImageJ":
 
     return _ij
 
+# -- Private functions -- #
 
 def _configure_imagej() -> Dict[str, Any]:
     """
-    Configures scyjava and pyimagej.
+    Configure scyjava and pyimagej.
     This function returns the settings that must be passed in the
     actual initialization call.
 
@@ -115,7 +116,7 @@ def _configure_imagej() -> Dict[str, Any]:
 
 def _validate_imagej():
     """
-    Helper function to ensure minimum requirements on java component versions
+    Ensure minimum requirements on java component versions are met.
     """
     # If we want to require a minimum version for a java component, we need to
     # be able to find our current version. We do that by querying a Java class

--- a/src/napari_imagej/model.py
+++ b/src/napari_imagej/model.py
@@ -1,0 +1,41 @@
+from jpype import JImplements, JOverride
+
+from napari_imagej.java import init_ij, jc
+
+
+class NapariImageJ:
+    """
+    An object offering a central access point to napari-imagej's core business logic.
+    """
+
+    def __init__(self):
+        self._ij = None
+        self._repl = None
+        self._repl_callbacks = []
+
+    @property
+    def ij(self):
+        if self._ij is None:
+            self._ij = init_ij()
+        return self._ij
+
+    @property
+    def repl(self) -> "jc.ScriptREPL":
+        if self._repl is None:
+            ctx = self.ij.context()
+            model = self
+
+            @JImplements("java.util.function.Consumer")
+            class REPLOutput:
+                @JOverride
+                def accept(self, t):
+                    s = str(t)
+                    for callback in model._repl_callbacks:
+                        callback(s)
+
+            self._repl = jc.ScriptREPL(ctx, "jython", REPLOutput())
+            self._repl.lang("jython")
+        return self._repl
+
+    def add_repl_callback(self, repl_callback) -> None:
+        self._repl_callbacks.append(repl_callback)

--- a/src/napari_imagej/model.py
+++ b/src/napari_imagej/model.py
@@ -33,8 +33,13 @@ class NapariImageJ:
                     for callback in model._repl_callbacks:
                         callback(s)
 
-            self._repl = jc.ScriptREPL(ctx, "jython", REPLOutput())
-            self._repl.lang("jython")
+            scriptService = ctx.service(jc.ScriptService)
+            # Find a Pythonic script language (might be Jython)
+            names = [lang.getLanguageName() for lang in scriptService.getLanguages()]
+            name_pref = next(n for n in names if "python" in n.toLowerCase())
+            self._repl = jc.ScriptREPL(ctx, name_pref, REPLOutput())
+            # NB: Adds bindings
+            self._repl.initialize(True)
         return self._repl
 
     def add_repl_callback(self, repl_callback) -> None:

--- a/src/napari_imagej/readers/trackMate_reader.py
+++ b/src/napari_imagej/readers/trackMate_reader.py
@@ -7,7 +7,8 @@ import xml.etree.ElementTree as ET
 from napari.utils import progress
 from scyjava import jimport
 
-from napari_imagej.java import ij, init_ij, jc
+from napari_imagej import nij
+from napari_imagej.java import jc
 from napari_imagej.types.converters.trackmate import (
     model_and_image_to_tracks,
     trackmate_present,
@@ -40,7 +41,7 @@ def napari_get_reader(path):
 
 def reader_function(path):
     pbr = progress(total=4, desc="Importing TrackMate XML: Starting JVM")
-    init_ij()
+    ij = nij.ij
     TmXMLReader = jimport("fiji.plugin.trackmate.io.TmXmlReader")
     pbr.update()
 
@@ -51,7 +52,7 @@ def reader_function(path):
     pbr.update()
 
     pbr.set_description("Importing TrackMate XML: Converting Image")
-    py_imp = ij().py.from_java(imp)
+    py_imp = ij.py.from_java(imp)
     pbr.update()
 
     pbr.set_description("Importing TrackMate XML: Converting Tracks and ROIs")

--- a/src/napari_imagej/resources/repl.svg
+++ b/src/napari_imagej/resources/repl.svg
@@ -29,19 +29,18 @@
      inkscape:groupmode="layer"
      id="layer1"
      transform="translate(-4.1093503,-5.8935793)">
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.64444px;font-family:'Mukta Mahee';-inkscape-font-specification:'Mukta Mahee, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke-width:0.264583"
-       x="3.7819726"
-       y="8.6762905"
+    <g
+       aria-label="&gt;_"
        id="text1010"
-       inkscape:export-filename="repl.svg"
-       inkscape:export-xdpi="91.139351"
-       inkscape:export-ydpi="91.139351"><tspan
-         sodipodi:role="line"
-         id="tspan1008"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.64444px;font-family:'Mukta Mahee';-inkscape-font-specification:'Mukta Mahee, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke-width:0.264583"
-         x="3.7819726"
-         y="8.6762905">&gt;_</tspan></text>
+       style="font-weight:bold;font-size:5.64444px;font-family:'Mukta Mahee';-inkscape-font-specification:'Mukta Mahee, Bold';stroke-width:0.264583">
+      <path
+         d="M 4.1093504,8.5916238 V 8.0158905 L 5.5881949,7.2426016 4.1093504,6.4693127 V 5.8935794 l 2.0545778,1.1458222 v 0.4120445 z"
+         style="font-size:5.64444px"
+         id="path2760" />
+      <path
+         d="M 8.5684558,9.6640683 V 10.087402 H 6.5308113 V 9.6640683 Z"
+         style="font-size:5.64444px"
+         id="path2762" />
+    </g>
   </g>
 </svg>

--- a/src/napari_imagej/resources/repl.svg
+++ b/src/napari_imagej/resources/repl.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="4.4591055mm"
+   height="4.1938229mm"
+   viewBox="0 0 4.4591055 4.1938229"
+   version="1.1"
+   id="svg5"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-4.1093503,-5.8935793)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.64444px;font-family:'Mukta Mahee';-inkscape-font-specification:'Mukta Mahee, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke-width:0.264583"
+       x="3.7819726"
+       y="8.6762905"
+       id="text1010"
+       inkscape:export-filename="repl.svg"
+       inkscape:export-xdpi="91.139351"
+       inkscape:export-ydpi="91.139351"><tspan
+         sodipodi:role="line"
+         id="tspan1008"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.64444px;font-family:'Mukta Mahee';-inkscape-font-specification:'Mukta Mahee, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke-width:0.264583"
+         x="3.7819726"
+         y="8.6762905">&gt;_</tspan></text>
+  </g>
+</svg>

--- a/src/napari_imagej/settings.py
+++ b/src/napari_imagej/settings.py
@@ -48,7 +48,7 @@ from napari_imagej.utilities.logging import log_debug, warn
 # -- Constants --
 
 default_java_components = [
-    "net.imagej:imagej:2.13.1",
+    "net.imagej:imagej:2.15.0",
 ]
 defaults = {
     "imagej_directory_or_endpoint": "",

--- a/src/napari_imagej/types/converters/images.py
+++ b/src/napari_imagej/types/converters/images.py
@@ -13,13 +13,14 @@ from numpy import ones
 from scyjava import Priority
 from xarray import DataArray
 
-from napari_imagej.java import ij, jc
+from napari_imagej import nij
+from napari_imagej.java import jc
 from napari_imagej.types.converters import java_to_py_converter, py_to_java_converter
 from napari_imagej.utilities.logging import log_debug
 
 
 @java_to_py_converter(
-    predicate=lambda obj: ij().convert().supports(obj, jc.DatasetView),
+    predicate=lambda obj: nij.ij.convert().supports(obj, jc.DatasetView),
     priority=Priority.VERY_HIGH + 1,
 )
 def _java_image_to_image_layer(image: Any) -> Image:
@@ -33,9 +34,9 @@ def _java_image_to_image_layer(image: Any) -> Image:
     :return: a napari Image layer
     """
     # Construct a DatasetView from the Java image
-    view = ij().convert().convert(image, jc.DatasetView)
+    view = nij.ij.convert().convert(image, jc.DatasetView)
     # Construct an xarray from the DatasetView
-    xarr: DataArray = java_to_xarray(ij(), view.getData())
+    xarr: DataArray = java_to_xarray(nij.ij, view.getData())
     # Construct a map of Image layer parameters
     kwargs = dict(
         data=xarr,
@@ -59,7 +60,7 @@ def _image_layer_to_dataset(image: Image, **kwargs) -> "jc.Dataset":
     :return: a Dataset
     """
     # Construct a dataset from the data
-    dataset: "jc.Dataset" = ij().py.to_dataset(image.data, **kwargs)
+    dataset: "jc.Dataset" = nij.ij.py.to_dataset(image.data, **kwargs)
 
     # Clean up the axes
     axes = [
@@ -94,7 +95,7 @@ def _image_layer_to_dataset(image: Image, **kwargs) -> "jc.Dataset":
     properties = dataset.getProperties()
     for k, v in image.metadata.items():
         try:
-            properties.put(ij().py.to_java(k), ij().py.to_java(v))
+            properties.put(nij.ij.py.to_java(k), nij.ij.py.to_java(v))
         except Exception:
             log_debug(f"Could not add property ({k}, {v}) to dataset {dataset}:")
     return dataset

--- a/src/napari_imagej/types/converters/labels.py
+++ b/src/napari_imagej/types/converters/labels.py
@@ -8,7 +8,8 @@ from labeling.Labeling import Labeling
 from napari.layers import Labels
 from scyjava import Priority
 
-from napari_imagej.java import ij, jc
+from napari_imagej import nij
+from napari_imagej.java import jc
 from napari_imagej.types.converters import java_to_py_converter, py_to_java_converter
 
 
@@ -42,7 +43,7 @@ def _imglabeling_to_layer(imgLabeling: "jc.ImgLabeling") -> Labels:
     :param imgLabeling: the Java ImgLabeling
     :return: a Labels layer
     """
-    labeling: Labeling = imglabeling_to_labeling(ij(), imgLabeling)
+    labeling: Labeling = imglabeling_to_labeling(nij.ij, imgLabeling)
     return _labeling_to_layer(labeling)
 
 
@@ -56,4 +57,4 @@ def _layer_to_imglabeling(layer: Labels) -> "jc.ImgLabeling":
     :return: the Java ImgLabeling
     """
     labeling: Labeling = _layer_to_labeling(layer)
-    return ij().py.to_java(labeling)
+    return nij.ij.py.to_java(labeling)

--- a/src/napari_imagej/types/converters/trackmate.py
+++ b/src/napari_imagej/types/converters/trackmate.py
@@ -6,8 +6,8 @@ import numpy as np
 from napari.layers import Labels, Tracks
 from scyjava import JavaClasses, Priority
 
-from napari_imagej import settings
-from napari_imagej.java import ij
+from napari_imagej import nij, settings
+from napari_imagej.java import NijJavaClasses
 from napari_imagej.types.converters import java_to_py_converter
 
 
@@ -36,7 +36,7 @@ def track_overlay_predicate(obj):
     if not trackmate_present():
         return False
     # TrackMate data is wrapped in ImageJ Rois - we need ImageJ Legacy
-    if not (ij().legacy and ij().legacy.isActive()):
+    if not (nij.ij.legacy and nij.ij.legacy.isActive()):
         return False
     # TrackMate data will be wrapped within a ROITree
     if not isinstance(obj, jc.ROITree):
@@ -106,7 +106,7 @@ def model_and_image_to_tracks(model: "jc.Model", imp: "jc.ImagePlus"):
     java_label_img = jc.LabelImgExporter.createLabelImagePlus(
         model, imp, False, False, False
     )
-    py_label_img = ij().py.from_java(java_label_img)
+    py_label_img = nij.ij.py.from_java(java_label_img)
     labels = Labels(data=py_label_img.data, name=rois_name)
 
     return (tracks, labels)
@@ -119,7 +119,7 @@ def _trackMate_model_to_tracks(obj: "jc.ROITree"):
     """
     Converts a TrackMate overlay into a napari Tracks layer
     """
-    trackmate_plugins = ij().object().getObjects(jc.TrackMate)
+    trackmate_plugins = nij.ij.object().getObjects(jc.TrackMate)
     if len(trackmate_plugins) == 0:
         raise IndexError("Expected a TrackMate instance, but there was none!")
     model: jc.Model = trackmate_plugins[-1].getModel()
@@ -127,7 +127,7 @@ def _trackMate_model_to_tracks(obj: "jc.ROITree"):
     return model_and_image_to_tracks(model, src_image)
 
 
-class TrackMateClasses(JavaClasses):
+class TrackMateClasses(NijJavaClasses):
     # TrackMate Types
 
     @JavaClasses.java_import

--- a/src/napari_imagej/types/converters/trackmate.py
+++ b/src/napari_imagej/types/converters/trackmate.py
@@ -4,10 +4,10 @@ from re import match
 
 import numpy as np
 from napari.layers import Labels, Tracks
-from scyjava import Priority
+from scyjava import JavaClasses, Priority
 
 from napari_imagej import settings
-from napari_imagej.java import JavaClasses, ij
+from napari_imagej.java import ij
 from napari_imagej.types.converters import java_to_py_converter
 
 
@@ -130,39 +130,39 @@ def _trackMate_model_to_tracks(obj: "jc.ROITree"):
 class TrackMateClasses(JavaClasses):
     # TrackMate Types
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def BranchTableView(self):
         return "fiji.plugin.trackmate.visualization.table.BranchTableView"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ConvexBranchesDecomposition(self):
         return "fiji.plugin.trackmate.graph.ConvexBranchesDecomposition"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def LabelImgExporter(self):
         return "fiji.plugin.trackmate.action.LabelImgExporter"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def Model(self):
         return "fiji.plugin.trackmate.Model"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def Spot(self):
         return "fiji.plugin.trackmate.Spot"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def SpotOverlay(self):
         return "fiji.plugin.trackmate.visualization.hyperstack.SpotOverlay"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def TMUtils(self):
         return "fiji.plugin.trackmate.util.TMUtils"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def TrackMate(self):
         return "fiji.plugin.trackmate.TrackMate"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def TrackOverlay(self):
         return "fiji.plugin.trackmate.visualization.hyperstack.TrackOverlay"
 

--- a/src/napari_imagej/types/type_conversions.py
+++ b/src/napari_imagej/types/type_conversions.py
@@ -22,7 +22,8 @@ from typing import Callable, List, Optional, Tuple, Type
 from jpype import JObject
 from scyjava import Priority
 
-from napari_imagej.java import ij, jc
+from napari_imagej import nij
+from napari_imagej.java import jc
 from napari_imagej.types.enum_likes import enum_like
 from napari_imagej.types.enums import py_enum_for
 from napari_imagej.types.type_hints import type_hints
@@ -202,6 +203,6 @@ def canConvertChecker(item: "jc.ModuleItem") -> Optional[Type]:
     """
 
     def isAssignable(from_type, to_type) -> bool:
-        return ij().convert().supports(from_type, to_type)
+        return nij.ij.convert().supports(from_type, to_type)
 
     return _checkerUsingFunc(item, isAssignable)

--- a/src/napari_imagej/utilities/event_subscribers.py
+++ b/src/napari_imagej/utilities/event_subscribers.py
@@ -6,7 +6,8 @@ napari-imagej functionality
 from jpype import JImplements, JOverride
 from qtpy.QtCore import Signal
 
-from napari_imagej.java import ij, jc
+from napari_imagej import nij
+from napari_imagej.java import jc
 from napari_imagej.utilities.logging import log_debug
 
 
@@ -52,7 +53,7 @@ class UIShownListener(object):
     def onEvent(self, event):
         if not self.initialized:
             # add our custom settings to the User Interface
-            if ij().legacy and ij().legacy.isActive():
+            if nij.ij.legacy and nij.ij.legacy.isActive():
                 self._ij1_UI_setup()
             self._ij2_UI_setup(event.getUI())
             self.initialized = True
@@ -67,7 +68,7 @@ class UIShownListener(object):
 
     def _ij1_UI_setup(self):
         """Configure the ImageJ Legacy GUI"""
-        ij().IJ.getInstance().exitWhenQuitting(False)
+        nij.ij.IJ.getInstance().exitWhenQuitting(False)
 
     def _ij2_UI_setup(self, ui: "jc.UserInterface"):
         """Configure the ImageJ2 Swing GUI behavior"""
@@ -120,5 +121,5 @@ class UIShownListener(object):
                 pass
 
         listener = NapariAdapter()
-        ij().object().addObject(listener)
+        nij.ij.object().addObject(listener)
         window.addWindowListener(listener)

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -270,11 +270,11 @@ class REPLButton(IJMenuButton):
 
         self.setEnabled(False)
 
-        icon = QColoredSVGIcon(resource_path("repl"))
-        self.setIcon(icon.colored(theme=viewer.theme))
-
         self.clicked.connect(self._toggle_repl)
         self._widget = None
+
+    def _icon(self):
+        return QColoredSVGIcon(resource_path("repl"))
 
     def _add_repl_to_dock(self):
         self._widget = REPLWidget(nij=nij)

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -296,7 +296,7 @@ class REPLButton(IJMenuButton):
 
     def _toggle_repl(self):
         """
-        Spawn a popup allowing the user to configure napari-imagej settings.
+        Toggle visibility the SciJava REPL widget.
         """
         if not self._widget:
             self._add_repl_to_dock()

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -279,7 +279,10 @@ class REPLButton(IJMenuButton):
     def _add_repl_to_dock(self):
         self._widget = REPLWidget(nij=nij)
         self._widget.visible = False
-        self.viewer.window.add_dock_widget(self._widget, name="napari-imagej REPL")
+        self.viewer.window.add_dock_widget(
+            self._widget,
+            name="napari-imagej REPL",
+        )
 
     def _toggle_repl(self):
         """

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -43,11 +43,9 @@ class NapariImageJMenu(QWidget):
         self.layout().addWidget(self.gui_button)
 
         self.repl_button: REPLButton = REPLButton(viewer)
-        self.repl_button.setToolTip("Show/hide the SciJava REPL")
         self.layout().addWidget(self.repl_button)
 
         self.settings_button: SettingsButton = SettingsButton(viewer)
-        self.settings_button.setToolTip("Show napari-imagej settings")
         self.layout().addWidget(self.settings_button)
 
         if settings.headless():
@@ -268,6 +266,7 @@ class REPLButton(IJMenuButton):
     def __init__(self, viewer: Viewer):
         super().__init__(viewer)
         self.viewer = viewer
+        self.setToolTip("Show/hide the SciJava REPL")
 
         self.setEnabled(False)
 
@@ -300,6 +299,7 @@ class SettingsButton(IJMenuButton):
 
     def __init__(self, viewer: Viewer):
         super().__init__(viewer)
+        self.setToolTip("Show napari-imagej settings")
 
         self.clicked.connect(self._update_settings)
         self.setting_change.connect(self._handle_settings_change)

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -280,8 +280,7 @@ class REPLButton(IJMenuButton):
         self._widget = REPLWidget(nij=nij)
         self._widget.visible = False
         self.viewer.window.add_dock_widget(
-            self._widget,
-            name="napari-imagej REPL",
+            self._widget, name="napari-imagej REPL", area="bottom"
         )
 
     def _toggle_repl(self):

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -77,6 +77,10 @@ class NapariImageJMenu(QWidget):
             self.gui_button.setIcon(self.gui_button._icon())
             self.gui_button.setEnabled(True)
             self.gui_button.setToolTip("Display ImageJ2 UI")
+
+        # Now the REPL can be enabled
+        self.repl_button.setEnabled(True)
+
         # Subscribe UIShownListener
         self.subscriber = UIShownListener()
         subscribe(ij(), self.subscriber)
@@ -265,6 +269,8 @@ class REPLButton(IJMenuButton):
     def __init__(self, viewer: Viewer):
         super().__init__(viewer)
         self.viewer = viewer
+
+        self.setEnabled(False)
 
         icon = QColoredSVGIcon(resource_path("repl"))
         self.setIcon(icon.colored(theme=viewer.theme))

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -281,15 +281,6 @@ class REPLButton(IJMenuButton):
         self._widget = None
 
     def _add_repl_to_dock(self):
-        from scyjava import jimport
-
-        ByteArrayOutputStream = jimport("java.io.ByteArrayOutputStream")
-        ScriptREPL = jimport("org.scijava.script.ScriptREPL")
-
-        output_stream = ByteArrayOutputStream()
-        self.repl = ScriptREPL(ij().context(), "jython", output_stream)
-        self.repl.lang("jython")
-
         self._widget = REPLWidget(self.repl)
         self._widget.visible = False
         self.viewer.window.add_dock_widget(self._widget, name="napari-imagej REPL")

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -284,7 +284,7 @@ class REPLButton(IJMenuButton):
 
         self._widget = REPLWidget(self.repl)
         self._widget.visible = False
-        self.viewer.window.add_dock_widget(self._widget)
+        self.viewer.window.add_dock_widget(self._widget, name="napari-imagej REPL")
 
     def _toggle_repl(self):
         """

--- a/src/napari_imagej/widgets/menu.py
+++ b/src/napari_imagej/widgets/menu.py
@@ -45,9 +45,11 @@ class NapariImageJMenu(QWidget):
         self.layout().addWidget(self.gui_button)
 
         self.repl_button: REPLButton = REPLButton(viewer)
+        self.repl_button.setToolTip("Show/hide the SciJava REPL")
         self.layout().addWidget(self.repl_button)
 
         self.settings_button: SettingsButton = SettingsButton(viewer)
+        self.settings_button.setToolTip("Show napari-imagej settings")
         self.layout().addWidget(self.settings_button)
 
         if settings.headless():

--- a/src/napari_imagej/widgets/repl.py
+++ b/src/napari_imagej/widgets/repl.py
@@ -6,11 +6,11 @@ This supports all of the languages of SciJava.
 from qtpy.QtGui import QTextCursor
 from qtpy.QtWidgets import QComboBox, QLineEdit, QTextEdit, QVBoxLayout, QWidget
 
-from napari_imagej.java import jc
+from napari_imagej.java import ij, jc
 
 
 class REPLWidget(QWidget):
-    def __init__(self, script_repl, parent=None):
+    def __init__(self, script_repl: "ScriptREPL" = None, parent: QWidget = None):
         """
         Initialize the REPLWidget.
 
@@ -18,7 +18,14 @@ class REPLWidget(QWidget):
         :param parent: The parent widget (optional).
         """
         super().__init__(parent)
-        self.script_repl = script_repl
+
+        output_stream = ByteArrayOutputStream()
+        self.script_repl = (
+            script_repl
+            if script_repl
+            else jc.ScriptREPL(ij().context(), output_stream)
+        )
+        self.script_repl.lang("jython")
 
         layout = QVBoxLayout(self)
 

--- a/src/napari_imagej/widgets/repl.py
+++ b/src/napari_imagej/widgets/repl.py
@@ -1,0 +1,86 @@
+"""
+A widget that provides access to the SciJava REPL.
+
+This supports all of the languages of SciJava.
+"""
+from qtpy.QtGui import QTextCursor
+from qtpy.QtWidgets import QComboBox, QLineEdit, QTextEdit, QVBoxLayout, QWidget
+
+
+class REPLWidget(QWidget):
+    def __init__(self, script_repl, parent=None):
+        """
+        Initialize the REPLWidget.
+
+        Parameters:
+        - script_repl (ScriptREPL): The ScriptREPL object for evaluating commands.
+        - parent (QWidget): The parent widget (optional).
+
+        Set up the user interface and connect signals for the REPLWidget.
+        """
+        super().__init__(parent)
+        self.script_repl = script_repl
+
+        layout = QVBoxLayout(self)
+
+        self.language_combo = QComboBox(self)
+        self.language_combo.addItems(
+            [str(el) for el in list(self.script_repl.getInterpretedLanguages())]
+        )
+        self.language_combo.currentTextChanged.connect(self.change_language)
+        layout.addWidget(self.language_combo)
+
+        self.output_textedit = QTextEdit(self)
+        self.output_textedit.setReadOnly(True)
+        layout.addWidget(self.output_textedit)
+
+        self.input_lineedit = QLineEdit(self)
+        self.input_lineedit.returnPressed.connect(self.process_input)
+        layout.addWidget(self.input_lineedit)
+
+    def change_language(self, language):
+        """
+        Change the scripting language of the ScriptREPL object.
+
+        Parameters:
+        - language (str): The selected scripting language.
+
+        Update the scripting language setting of the ScriptREPL object based on
+        the user's selection.
+        """
+        self.script_repl.lang(language)
+        self.output_textedit.clear()
+
+    def process_input(self):
+        """
+        Process the user input and evaluate it using the ScriptREPL.
+
+        Display the results in the output text area.
+        """
+        input_text = self.input_lineedit.text()
+        self.input_lineedit.clear()
+
+        from scyjava import jimport
+
+        ScriptException = jimport("javax.script.ScriptException")
+
+        # Catch script errors when evaluating
+        try:
+            # Evaluate the input using interpreter's eval method
+            result = self.script_repl.getInterpreter().eval(input_text)
+
+            # Display the result in the output text area
+            self.output_textedit.append(f">>> {input_text}")
+            self.output_textedit.append(str(result))
+        except ScriptException as e:
+            # Display the exception message in the output text area
+            self.output_textedit.append(f">>> {input_text}")
+            self.output_textedit.append(f"Error: {str(e)}")
+        finally:
+            self.output_textedit.append("")
+
+        # Scroll to the bottom of the output text area
+        cursor = self.output_textedit.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        self.output_textedit.setTextCursor(cursor)
+        self.output_textedit.ensureCursorVisible()

--- a/src/napari_imagej/widgets/repl.py
+++ b/src/napari_imagej/widgets/repl.py
@@ -6,6 +6,8 @@ This supports all of the languages of SciJava.
 from qtpy.QtGui import QTextCursor
 from qtpy.QtWidgets import QComboBox, QLineEdit, QTextEdit, QVBoxLayout, QWidget
 
+from napari_imagej.java import jc
+
 
 class REPLWidget(QWidget):
     def __init__(self, script_repl, parent=None):
@@ -60,10 +62,6 @@ class REPLWidget(QWidget):
         input_text = self.input_lineedit.text()
         self.input_lineedit.clear()
 
-        from scyjava import jimport
-
-        ScriptException = jimport("javax.script.ScriptException")
-
         # Catch script errors when evaluating
         try:
             # Evaluate the input using interpreter's eval method
@@ -72,7 +70,7 @@ class REPLWidget(QWidget):
             # Display the result in the output text area
             self.output_textedit.append(f">>> {input_text}")
             self.output_textedit.append(str(result))
-        except ScriptException as e:
+        except jc.ScriptException as e:
             # Display the exception message in the output text area
             self.output_textedit.append(f">>> {input_text}")
             self.output_textedit.append(f"Error: {str(e)}")

--- a/src/napari_imagej/widgets/repl.py
+++ b/src/napari_imagej/widgets/repl.py
@@ -14,11 +14,8 @@ class REPLWidget(QWidget):
         """
         Initialize the REPLWidget.
 
-        Parameters:
-        - script_repl (ScriptREPL): The ScriptREPL object for evaluating commands.
-        - parent (QWidget): The parent widget (optional).
-
-        Set up the user interface and connect signals for the REPLWidget.
+        :param script_repl: The ScriptREPL object for evaluating commands.
+        :param parent: The parent widget (optional).
         """
         super().__init__(parent)
         self.script_repl = script_repl
@@ -40,22 +37,18 @@ class REPLWidget(QWidget):
         self.input_lineedit.returnPressed.connect(self.process_input)
         layout.addWidget(self.input_lineedit)
 
-    def change_language(self, language):
+    def change_language(self, language: str):
         """
-        Change the scripting language of the ScriptREPL object.
+        Change the active scripting language of the REPL.
 
-        Parameters:
-        - language (str): The selected scripting language.
-
-        Update the scripting language setting of the ScriptREPL object based on
-        the user's selection.
+        :param language: The new scripting language to use.
         """
         self.script_repl.lang(language)
         self.output_textedit.clear()
 
     def process_input(self):
         """
-        Process the user input and evaluate it using the ScriptREPL.
+        Process the user input and evaluate it using the REPL.
 
         Display the results in the output text area.
         """

--- a/src/napari_imagej/widgets/repl.py
+++ b/src/napari_imagej/widgets/repl.py
@@ -3,29 +3,24 @@ A widget that provides access to the SciJava REPL.
 
 This supports all of the languages of SciJava.
 """
+
 from qtpy.QtGui import QTextCursor
 from qtpy.QtWidgets import QComboBox, QLineEdit, QTextEdit, QVBoxLayout, QWidget
 
-from napari_imagej.java import ij, jc
+from napari_imagej.model import NapariImageJ
 
 
 class REPLWidget(QWidget):
-    def __init__(self, script_repl: "ScriptREPL" = None, parent: QWidget = None):
+    def __init__(self, nij: NapariImageJ, parent: QWidget = None):
         """
         Initialize the REPLWidget.
 
-        :param script_repl: The ScriptREPL object for evaluating commands.
+        :param nij: The NapariImageJ model object to use when evaluating commands.
         :param parent: The parent widget (optional).
         """
         super().__init__(parent)
 
-        output_stream = ByteArrayOutputStream()
-        self.script_repl = (
-            script_repl
-            if script_repl
-            else jc.ScriptREPL(ij().context(), output_stream)
-        )
-        self.script_repl.lang("jython")
+        self.script_repl = nij.repl
 
         layout = QVBoxLayout(self)
 
@@ -39,6 +34,8 @@ class REPLWidget(QWidget):
         self.output_textedit = QTextEdit(self)
         self.output_textedit.setReadOnly(True)
         layout.addWidget(self.output_textedit)
+
+        nij.add_repl_callback(lambda s: self.process_output(s))
 
         self.input_lineedit = QLineEdit(self)
         self.input_lineedit.returnPressed.connect(self.process_input)
@@ -56,28 +53,21 @@ class REPLWidget(QWidget):
     def process_input(self):
         """
         Process the user input and evaluate it using the REPL.
-
-        Display the results in the output text area.
         """
         input_text = self.input_lineedit.text()
         self.input_lineedit.clear()
 
-        # Catch script errors when evaluating
-        try:
-            # Evaluate the input using interpreter's eval method
-            result = self.script_repl.getInterpreter().eval(input_text)
+        # Evaluate the input using REPL's evaluate method.
+        self.output_textedit.append(f">>> {input_text}")
+        self.script_repl.evaluate(input_text)
 
-            # Display the result in the output text area
-            self.output_textedit.append(f">>> {input_text}")
-            self.output_textedit.append(str(result))
-        except jc.ScriptException as e:
-            # Display the exception message in the output text area
-            self.output_textedit.append(f">>> {input_text}")
-            self.output_textedit.append(f"Error: {str(e)}")
-        finally:
-            self.output_textedit.append("")
+    def process_output(self, s):
+        """
+        Display output given from the REPL in the output text area.
+        """
+        self.output_textedit.append(s)
 
-        # Scroll to the bottom of the output text area
+        # Scroll to the bottom of the output text area.
         cursor = self.output_textedit.textCursor()
         cursor.movePosition(QTextCursor.MoveOperation.End)
         self.output_textedit.setTextCursor(cursor)

--- a/src/napari_imagej/widgets/repl.py
+++ b/src/napari_imagej/widgets/repl.py
@@ -20,15 +20,9 @@ class REPLWidget(QWidget):
         """
         super().__init__(parent)
 
-        self.script_repl = nij.repl
-
         layout = QVBoxLayout(self)
 
         self.language_combo = QComboBox(self)
-        self.language_combo.addItems(
-            [str(el) for el in list(self.script_repl.getInterpretedLanguages())]
-        )
-        self.language_combo.currentTextChanged.connect(self.change_language)
         layout.addWidget(self.language_combo)
 
         self.output_textedit = QTextEdit(self)
@@ -40,6 +34,15 @@ class REPLWidget(QWidget):
         self.input_lineedit = QLineEdit(self)
         self.input_lineedit.returnPressed.connect(self.process_input)
         layout.addWidget(self.input_lineedit)
+
+        self.script_repl = nij.repl
+        self.language_combo.addItems(
+            [str(el) for el in list(self.script_repl.getInterpretedLanguages())]
+        )
+        self.language_combo.setCurrentText(
+            str(self.script_repl.getInterpreter().getLanguage())
+        )
+        self.language_combo.currentTextChanged.connect(self.change_language)
 
     def change_language(self, language: str):
         """

--- a/src/napari_imagej/widgets/repl.py
+++ b/src/napari_imagej/widgets/repl.py
@@ -5,7 +5,14 @@ This supports all of the languages of SciJava.
 """
 
 from qtpy.QtGui import QTextCursor
-from qtpy.QtWidgets import QComboBox, QLineEdit, QTextEdit, QVBoxLayout, QWidget
+from qtpy.QtWidgets import (
+    QComboBox,
+    QHBoxLayout,
+    QLineEdit,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
 
 from napari_imagej.model import NapariImageJ
 
@@ -22,18 +29,21 @@ class REPLWidget(QWidget):
 
         layout = QVBoxLayout(self)
 
-        self.language_combo = QComboBox(self)
-        layout.addWidget(self.language_combo)
-
         self.output_textedit = QTextEdit(self)
         self.output_textedit.setReadOnly(True)
         layout.addWidget(self.output_textedit)
 
         nij.add_repl_callback(lambda s: self.process_output(s))
 
+        h_layout = QHBoxLayout()
+        layout.addLayout(h_layout)
+
+        self.language_combo = QComboBox(self)
+        h_layout.addWidget(self.language_combo)
+
         self.input_lineedit = QLineEdit(self)
         self.input_lineedit.returnPressed.connect(self.process_input)
-        layout.addWidget(self.input_lineedit)
+        h_layout.addWidget(self.input_lineedit)
 
         self.script_repl = nij.repl
         self.language_combo.addItems(

--- a/src/napari_imagej/widgets/result_tree.py
+++ b/src/napari_imagej/widgets/result_tree.py
@@ -13,7 +13,8 @@ from qtpy.QtGui import QStandardItem, QStandardItemModel
 from qtpy.QtWidgets import QAction, QMenu, QTreeView
 from scyjava import Priority
 
-from napari_imagej.java import ij, jc
+from napari_imagej import nij
+from napari_imagej.java import jc
 from napari_imagej.utilities.logging import log_debug
 from napari_imagej.widgets.widget_utils import _get_icon, python_actions_for
 
@@ -85,13 +86,13 @@ class SearcherItem(QStandardItem):
 
         # Finding the priority is tricky - Searchers don't know their priority
         # To find it we have to ask the pluginService.
-        plugin_info = ij().plugin().getPlugin(searcher.getClass())
+        plugin_info = nij.ij.plugin().getPlugin(searcher.getClass())
         self.priority = plugin_info.getPriority() if plugin_info else Priority.NORMAL
 
         # Set QtPy properties
         self.setEditable(False)
         self.setFlags(self.flags() | Qt.ItemIsUserCheckable)
-        checked = ij().get("org.scijava.search.SearchService").enabled(searcher)
+        checked = nij.ij.get("org.scijava.search.SearchService").enabled(searcher)
         self.setCheckState(Qt.Checked if checked else Qt.Unchecked)
 
     def __lt__(self, other):
@@ -172,7 +173,7 @@ class SearchResultModel(QStandardItemModel):
     def _detect_check_change(self, item):
         if isinstance(item, SearcherItem):
             checked = item.checkState() == Qt.Checked
-            ij().get("org.scijava.search.SearchService").setEnabled(
+            nij.ij.get("org.scijava.search.SearchService").setEnabled(
                 item.searcher, checked
             )
             if not checked and item.hasChildren():

--- a/src/napari_imagej/widgets/widget_utils.py
+++ b/src/napari_imagej/widgets/widget_utils.py
@@ -22,7 +22,8 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from napari_imagej.java import ij, jc
+from napari_imagej import nij
+from napari_imagej.java import jc
 from napari_imagej.utilities._module_utils import (
     execute_function_modally,
     functionify_module_execution,
@@ -36,7 +37,7 @@ def python_actions_for(
 ):
     actions = []
     # Iterate over all available python actions
-    searchService = ij().get("org.scijava.search.SearchService")
+    searchService = nij.ij.get("org.scijava.search.SearchService")
     for action in searchService.actions(result):
         action_name = str(action.toString())
         # Add buttons for the java action
@@ -61,8 +62,8 @@ def _run_actions_for(
             return []
 
         if (
-            ij().legacy
-            and ij().legacy.isActive()
+            nij.ij.legacy
+            and nij.ij.legacy.isActive()
             and isinstance(moduleInfo, jc.LegacyCommandInfo)
         ):
             reply = QMessageBox.question(
@@ -76,10 +77,10 @@ def _run_actions_for(
                 QMessageBox.Yes | QMessageBox.No,
             )
             if reply == QMessageBox.Yes:
-                ij().thread().queue(lambda: ij().ui().showUI())
+                nij.ij.thread().queue(lambda: nij.ij.ui().showUI())
             return
 
-        module = ij().module().createModule(moduleInfo)
+        module = nij.ij.module().createModule(moduleInfo)
 
         # preprocess using napari GUI
         func, param_options = functionify_module_execution(
@@ -283,15 +284,15 @@ class DetailExportDialog(QDialog):
             img = self.img_container.combo.currentData()
             roi = self.roi_container.combo.currentData()
             # Convert the selections to Java equivalents
-            j_img = ij().py.to_java(
+            j_img = nij.ij.py.to_java(
                 img, dim_order=self.dims_container.provided_labels()
             )
             if roi:
-                j_img.getProperties().put("rois", ij().py.to_java(roi))
+                j_img.getProperties().put("rois", nij.ij.py.to_java(roi))
             # Show the resulting image
-            ij().ui().show(j_img)
+            nij.ij.ui().show(j_img)
 
-        ij().thread().queue(lambda: pass_to_ij())
+        nij.ij.thread().queue(lambda: pass_to_ij())
 
 
 @lru_cache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,7 @@ from typing import Callable, Generator
 import pytest
 from napari import Viewer
 
-from napari_imagej import settings
-from napari_imagej.java import init_ij
+from napari_imagej import nij, settings
 from napari_imagej.widgets.menu import NapariImageJMenu
 from napari_imagej.widgets.napari_imagej import NapariImageJWidget
 
@@ -48,10 +47,10 @@ def ij():
     # if we don't add this.
     if sys.platform == "darwin":
         viewer = Viewer()
-        ij = init_ij()
+        ij = nij.ij
         viewer.close()
     else:
-        ij = init_ij()
+        ij = nij.ij
 
     yield ij
 
@@ -92,7 +91,7 @@ def gui_widget(viewer) -> Generator[NapariImageJMenu, None, None]:
     widget: NapariImageJMenu = NapariImageJMenu(viewer)
 
     # Wait for ImageJ initialization
-    init_ij()
+    _ = nij.ij
 
     # Finalize widget
     widget.finalize()

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -4,7 +4,7 @@ A module testing script discovery and wrapping
 
 from magicgui import magicgui
 
-from napari_imagej.java import JavaClasses
+from scyjava import JavaClasses
 from napari_imagej.utilities._module_utils import functionify_module_execution
 
 
@@ -13,7 +13,7 @@ class JavaClassesTest(JavaClasses):
     Here we override JavaClasses to get extra test imports
     """
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def DefaultModuleService(self):
         return "org.scijava.module.DefaultModuleService"
 

--- a/tests/test_scripting.py
+++ b/tests/test_scripting.py
@@ -3,8 +3,8 @@ A module testing script discovery and wrapping
 """
 
 from magicgui import magicgui
-
 from scyjava import JavaClasses
+
 from napari_imagej.utilities._module_utils import functionify_module_execution
 
 

--- a/tests/types/test_trackmate.py
+++ b/tests/types/test_trackmate.py
@@ -6,23 +6,23 @@ from typing import Tuple
 
 import numpy as np
 import pytest
+from scyjava import JavaClasses
 from napari.layers import Labels, Tracks
 
 from napari_imagej import settings
-from napari_imagej.java import JavaClasses
 from napari_imagej.types.converters.trackmate import TrackMateClasses, trackmate_present
 
 
 class TestTrackMateClasses(TrackMateClasses):
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def DisplaySettings(self):
         return "fiji.plugin.trackmate.gui.displaysettings.DisplaySettings"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def HyperStackDisplayer(self):
         return "fiji.plugin.trackmate.visualization.hyperstack.HyperStackDisplayer"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def SelectionModel(self):
         return "fiji.plugin.trackmate.SelectionModel"
 

--- a/tests/types/test_trackmate.py
+++ b/tests/types/test_trackmate.py
@@ -6,8 +6,8 @@ from typing import Tuple
 
 import numpy as np
 import pytest
-from scyjava import JavaClasses
 from napari.layers import Labels, Tracks
+from scyjava import JavaClasses
 
 from napari_imagej import settings
 from napari_imagej.types.converters.trackmate import TrackMateClasses, trackmate_present

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,10 +4,10 @@ A module containing testing utilities
 
 from typing import List
 
-from napari_imagej.java import NijJavaClasses
 from jpype import JImplements, JOverride
-
 from scyjava import JavaClasses
+
+from napari_imagej.java import NijJavaClasses
 
 
 class JavaClassesTest(NijJavaClasses):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,125 +4,126 @@ A module containing testing utilities
 
 from typing import List
 
+from napari_imagej.java import NijJavaClasses
 from jpype import JImplements, JOverride
 
-from napari_imagej.java import JavaClasses
+from scyjava import JavaClasses
 
 
-class JavaClassesTest(JavaClasses):
+class JavaClassesTest(NijJavaClasses):
     """
     Here we override JavaClasses to get extra test imports
     """
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ArrayImg(self):
         return "net.imglib2.img.array.ArrayImg"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ArrayImgs(self):
         return "net.imglib2.img.array.ArrayImgs"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def Axes(self):
         return "net.imagej.axis.Axes"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def BoolType(self):
         return "net.imglib2.type.logic.BoolType"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ByteType(self):
         return "net.imglib2.type.numeric.integer.ByteType"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ClassesSearcher(self):
         return "org.scijava.search.classes.ClassesSearcher"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ClassSearchResult(self):
         return "org.scijava.search.classes.ClassSearchResult"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def DefaultMutableModuleItem(self):
         return "org.scijava.module.DefaultMutableModuleItem"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def DefaultMutableModuleInfo(self):
         return "org.scijava.module.DefaultMutableModuleInfo"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def DoubleArray(self):
         return "org.scijava.util.DoubleArray"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def EuclideanSpace(self):
         return "net.imglib2.EuclideanSpace"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def FloatType(self):
         return "net.imglib2.type.numeric.real.FloatType"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def Frame(self):
         return "java.awt.Frame"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def IllegalArgumentException(self):
         return "java.lang.IllegalArgumentException"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ImageDisplay(self):
         return "net.imagej.display.ImageDisplay"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def IntType(self):
         return "net.imglib2.type.numeric.integer.IntType"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ItemIO(self):
         return "org.scijava.ItemIO"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ItemVisibility(self):
         return "org.scijava.ItemVisibility"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ModuleSearchResult(self):
         return "org.scijava.search.module.ModuleSearchResult"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def OpSearchResult(self):
         return "net.imagej.ops.search.OpSearchResult"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ScriptInfo(self):
         return "org.scijava.script.ScriptInfo"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ShortType(self):
         return "net.imglib2.type.numeric.integer.ShortType"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def System(self):
         return "java.lang.System"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def UnsignedByteType(self):
         return "net.imglib2.type.numeric.integer.UnsignedByteType"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def UnsignedShortType(self):
         return "net.imglib2.type.numeric.integer.UnsignedShortType"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def UnsignedIntType(self):
         return "net.imglib2.type.numeric.integer.UnsignedIntType"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def UnsignedLongType(self):
         return "net.imglib2.type.numeric.integer.UnsignedLongType"
 
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def WindowEvent(self):
         return "java.awt.event.WindowEvent"
 

--- a/tests/widgets/test_menu.py
+++ b/tests/widgets/test_menu.py
@@ -27,6 +27,7 @@ from napari_imagej.widgets.menu import (
     FromIJButton,
     GUIButton,
     NapariImageJMenu,
+    REPLButton,
     SettingsButton,
     ToIJButton,
     ToIJDetailedButton,
@@ -175,14 +176,15 @@ def clean_gui_elements(asserter, ij, viewer: Viewer):
 def test_widget_layout(gui_widget: NapariImageJMenu):
     """Tests the number and expected order of imagej_widget children"""
     subwidgets = gui_widget.children()
-    assert len(subwidgets) == 6
+    assert len(subwidgets) == 7
     assert isinstance(subwidgets[0], QHBoxLayout)
 
     assert isinstance(subwidgets[1], FromIJButton)
     assert isinstance(subwidgets[2], ToIJButton)
     assert isinstance(subwidgets[3], ToIJDetailedButton)
     assert isinstance(subwidgets[4], GUIButton)
-    assert isinstance(subwidgets[5], SettingsButton)
+    assert isinstance(subwidgets[5], REPLButton)
+    assert isinstance(subwidgets[6], SettingsButton)
 
 
 def test_GUIButton_layout_headful(qtbot, asserter, ij, gui_widget: NapariImageJMenu):

--- a/tests/widgets/test_menu.py
+++ b/tests/widgets/test_menu.py
@@ -237,6 +237,20 @@ def test_GUIButton_layout_headless(popup_handler, gui_widget: NapariImageJMenu):
     popup_handler(button.clicked.emit, popup_func)
 
 
+def test_script_repl(asserter, qtbot, ij, viewer: Viewer, gui_widget: NapariImageJMenu):
+    repl_button = gui_widget.repl_button
+
+    # Press the button - ensure the script repl appears as a dock widget
+    qtbot.mouseClick(repl_button, Qt.LeftButton, delay=1)
+
+    # the Viewer gives us no (public) API to query dock widgets,
+    # so the best we can do is to ensure that the parent is set on our widget
+    def find_repl() -> bool:
+        return repl_button._widget.parent() is not None
+
+    asserter(find_repl)
+
+
 def test_active_data_send(asserter, qtbot, ij, gui_widget: NapariImageJMenu):
     if settings.headless():
         pytest.skip("Only applies when not running headlessly")

--- a/tests/widgets/test_napari_imagej.py
+++ b/tests/widgets/test_napari_imagej.py
@@ -8,7 +8,7 @@ from numpy import ones
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication, QLabel, QPushButton, QTextEdit, QVBoxLayout
 
-from napari_imagej.java import ij
+from napari_imagej import nij
 from napari_imagej.utilities.event_subscribers import (
     ProgressBarListener,
     UIShownListener,
@@ -63,7 +63,7 @@ def _run_buttons(imagej_widget: NapariImageJWidget):
 def _ensure_searchers_available(imagej_widget: NapariImageJWidget, asserter):
     tree = imagej_widget.result_tree
     # Find the ModuleSearcher
-    numSearchers = len(ij().plugin().getPluginsOfType(jc.Searcher))
+    numSearchers = len(nij.ij.plugin().getPluginsOfType(jc.Searcher))
     try:
         asserter(lambda: tree.topLevelItemCount() == numSearchers)
     except Exception:
@@ -181,7 +181,7 @@ def test_imagej_search_tree_disable(ij, imagej_widget: NapariImageJWidget, asser
     # Disable the searcher, assert the proper ImageJ response
     searcher_item.setCheckState(Qt.Unchecked)
     asserter(
-        lambda: not ij.get("org.scijava.search.SearchService").enabled(
+        lambda: not nij.ij.get("org.scijava.search.SearchService").enabled(
             searcher_item.searcher
         )
     )
@@ -189,7 +189,7 @@ def test_imagej_search_tree_disable(ij, imagej_widget: NapariImageJWidget, asser
     # Enabled the searcher, assert the proper ImageJ response
     searcher_item.setCheckState(Qt.Checked)
     asserter(
-        lambda: ij.get("org.scijava.search.SearchService").enabled(
+        lambda: nij.ij.get("org.scijava.search.SearchService").enabled(
             searcher_item.searcher
         )
     )
@@ -201,7 +201,7 @@ def test_widget_finalization(ij, imagej_widget: NapariImageJWidget, asserter):
 
     # Ensure that all Searchers are represented in the tree with a top level
     # item
-    numSearchers = len(ij.plugin().getPluginsOfType(jc.Searcher))
+    numSearchers = len(nij.ij.plugin().getPluginsOfType(jc.Searcher))
     root = imagej_widget.result_tree.model().invisibleRootItem()
     asserter(lambda: root.rowCount() == numSearchers)
 
@@ -248,12 +248,12 @@ def test_info_validity(imagej_widget: NapariImageJWidget, qtbot, asserter):
     """
 
     # Wait for the info to populate
-    ij()
+    ij = nij.ij
 
     # Check the version
     info_box = imagej_widget.info_box
 
-    asserter(lambda: info_box.version_bar.text() == f"ImageJ2 v{ij().getVersion()}")
+    asserter(lambda: info_box.version_bar.text() == f"ImageJ2 v{ij.getVersion()}")
 
 
 def test_handle_output_layer(imagej_widget: NapariImageJWidget, qtbot, asserter):

--- a/tests/widgets/test_result_runner.py
+++ b/tests/widgets/test_result_runner.py
@@ -5,13 +5,13 @@ A module testing napari_imagej.widgets.result_runner
 import pytest
 from qtpy.QtWidgets import QLabel, QVBoxLayout, QWidget
 
-from napari_imagej.java import JavaClasses
+from scyjava import JavaClasses
 from napari_imagej.widgets.layouts import QFlowLayout
 from napari_imagej.widgets.result_runner import ResultRunner
 
 
 class JavaClassesTest(JavaClasses):
-    @JavaClasses.blocking_import
+    @JavaClasses.java_import
     def ModuleSearchResult(self):
         return "org.scijava.search.module.ModuleSearchResult"
 

--- a/tests/widgets/test_result_runner.py
+++ b/tests/widgets/test_result_runner.py
@@ -4,8 +4,8 @@ A module testing napari_imagej.widgets.result_runner
 
 import pytest
 from qtpy.QtWidgets import QLabel, QVBoxLayout, QWidget
-
 from scyjava import JavaClasses
+
 from napari_imagej.widgets.layouts import QFlowLayout
 from napari_imagej.widgets.result_runner import ResultRunner
 


### PR DESCRIPTION
This PR adds a widget for the SciJava ScriptREPL, allowing users to interactively write SciJava friendly code directly within napari.

When I was exploring the compatibility of various ImageJ/Fiji plugins with napari-imagej, I frequently found myself wanting to poke at variables/state. That led me to writing this REPL widget so we can quickly poke around on the JVM instead of always needing to deal with jpipe/jimport stuff.

![napari_imagej_repl_001](https://github.com/imagej/napari-imagej/assets/400105/337ed9d5-af03-4464-a98c-dc5890cdecd0)
Caption: This is a screenshot of napari-imagej with the REPL widget active and some example output from  Jython.

Now updated to have the corrected icon:
<img width="1004" alt="image" src="https://github.com/imagej/napari-imagej/assets/400105/d186a9d4-cd7e-4e0c-b5e1-f7a49d3628ee">
