### PR TITLE
Remove usages of isjava

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "numpy",
     "pandas",
     "pyimagej >= 1.4.1",
-    "scyjava >= 1.8.1",
+    "scyjava >= 1.9.1",
     # Version rules to avoid problems
     "qtconsole != 5.4.2", # https://github.com/napari/napari/issues/5700
     "typing_extensions != 4.6.0", # https://github.com/pydantic/pydantic/issues/5821

--- a/src/napari_imagej/types/converters/images.py
+++ b/src/napari_imagej/types/converters/images.py
@@ -10,7 +10,7 @@ from jpype import JArray, JByte
 from napari.layers import Image
 from napari.utils.colormaps import Colormap
 from numpy import ones
-from scyjava import Priority, isjava
+from scyjava import Priority
 from xarray import DataArray
 
 from napari_imagej.java import ij, jc
@@ -19,7 +19,7 @@ from napari_imagej.utilities.logging import log_debug
 
 
 @java_to_py_converter(
-    predicate=lambda obj: isjava(obj) and ij().convert().supports(obj, jc.DatasetView),
+    predicate=lambda obj: ij().convert().supports(obj, jc.DatasetView),
     priority=Priority.VERY_HIGH + 1,
 )
 def _java_image_to_image_layer(image: Any) -> Image:

--- a/src/napari_imagej/utilities/_module_utils.py
+++ b/src/napari_imagej/utilities/_module_utils.py
@@ -19,15 +19,7 @@ from magicgui.widgets import Container, Label, LineEdit, Table, Widget, request_
 from napari.layers import Layer
 from napari.utils._magicgui import get_layers
 from pandas import DataFrame
-from scyjava import (
-    JavaIterable,
-    JavaList,
-    JavaMap,
-    JavaSet,
-    is_arraylike,
-    isjava,
-    jstacktrace,
-)
+from scyjava import JavaIterable, JavaList, JavaMap, JavaSet, is_arraylike, jstacktrace
 
 from napari_imagej.java import ij, jc
 from napari_imagej.types.type_conversions import type_hint_for
@@ -397,7 +389,7 @@ def _add_param_metadata(metadata: dict, key: str, value: Any) -> None:
     if value is None:
         return
     try:
-        py_value = ij().py.from_java(value) if isjava(value) else value
+        py_value = ij().py.from_java(value)
         if isinstance(py_value, JavaMap):
             py_value = dict(py_value)
         elif isinstance(py_value, JavaSet):

--- a/src/napari_imagej/widgets/napari_imagej.py
+++ b/src/napari_imagej/widgets/napari_imagej.py
@@ -13,7 +13,7 @@ from napari import Viewer
 from napari.layers import Layer
 from qtpy.QtCore import QThread, Signal, Slot
 from qtpy.QtWidgets import QTreeWidgetItem, QVBoxLayout, QWidget
-from scyjava import isjava, jstacktrace, when_jvm_stops
+from scyjava import jstacktrace, when_jvm_stops
 
 from napari_imagej.java import ij, init_ij, jc
 from napari_imagej.utilities._module_utils import _non_layer_widget
@@ -207,9 +207,8 @@ class NapariImageJWidget(QWidget):
         self.search.bar.finalize_on_error()
         # Print thet error
         title = "ImageJ could not be initialized, due to the following error:"
-        if isjava(exc):
-            exception_str = jstacktrace(exc)
-        else:
+        exception_str = jstacktrace(exc)
+        if not exception_str:
             # NB 3-arg function needed in Python < 3.10
             exception_list = format_exception(type(exc), exc, exc.__traceback__)
             exception_str = "".join(exception_list)


### PR DESCRIPTION
And bump minimum scyjava version to 1.9.1.

As of scyjava 1.9.1, the work from scijava/scyjava#60 is integrated, meaning such defensive checks around conversion are no longer necessary.

This reverts commit 85f0d5c42659a326d0ce96c7b5534d7c8c4a5d2c, titled "Work around jpype convert limitation", and closes #220.

It also removes some other usages of isjava, which are also not needed.
