### PR TITLE
Switch SearchResult display to model/view paradigm

### DIFF
--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -287,6 +287,10 @@ class JavaClasses(object):
         return "java.math.BigInteger"
 
     @blocking_import
+    def ByteArrayOutputStream(self):
+        return "java.io.ByteArrayOutputStream"
+
+    @blocking_import
     def Date(self):
         return "java.util.Date"
 

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -299,20 +299,12 @@ class JavaClasses(object):
         return "java.io.File"
 
     @blocking_import
-    def Files(self):
-        return "java.nio.file.Files"
-
-    @blocking_import
     def HashMap(self):
         return "java.util.HashMap"
 
     @blocking_import
     def Path(self):
         return "java.nio.file.Path"
-
-    @blocking_import
-    def StandardCopyOption(self):
-        return "java.nio.file.StandardCopyOption"
 
     @blocking_import
     def Window(self):

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -299,12 +299,20 @@ class JavaClasses(object):
         return "java.io.File"
 
     @blocking_import
+    def Files(self):
+        return "java.nio.file.Files"
+
+    @blocking_import
     def HashMap(self):
         return "java.util.HashMap"
 
     @blocking_import
     def Path(self):
         return "java.nio.file.Path"
+
+    @blocking_import
+    def StandardCopyOption(self):
+        return "java.nio.file.StandardCopyOption"
 
     @blocking_import
     def Window(self):

--- a/src/napari_imagej/widgets/result_tree.py
+++ b/src/napari_imagej/widgets/result_tree.py
@@ -3,6 +3,7 @@ A QWidget designed to list SciJava SearchResults.
 
 SearchResults are grouped by the SciJava Searcher that created them.
 """
+
 from typing import Dict, List
 
 from qtpy.QtCore import Qt, Signal
@@ -87,7 +88,7 @@ class SearcherItem(QStandardItem):
 
         # Set QtPy properties
         self.setEditable(False)
-        self.setFlags((self.flags() & ~Qt.ItemIsSelectable) | Qt.ItemIsUserCheckable)
+        self.setFlags(self.flags() | Qt.ItemIsUserCheckable)
         checked = ij().get("org.scijava.search.SearchService").enabled(searcher)
         self.setCheckState(Qt.Checked if checked else Qt.Unchecked)
 

--- a/src/napari_imagej/widgets/result_tree.py
+++ b/src/napari_imagej/widgets/result_tree.py
@@ -3,18 +3,16 @@ A QWidget designed to list SciJava SearchResults.
 
 SearchResults are grouped by the SciJava Searcher that created them.
 """
-import tempfile
-from functools import lru_cache
 from typing import Dict, List
 
 from qtpy.QtCore import Qt, Signal
-from qtpy.QtGui import QIcon, QStandardItem, QStandardItemModel
+from qtpy.QtGui import QStandardItem, QStandardItemModel
 from qtpy.QtWidgets import QAction, QMenu, QTreeView
 from scyjava import Priority
 
 from napari_imagej.java import ij, jc
 from napari_imagej.utilities.logging import log_debug
-from napari_imagej.widgets.widget_utils import python_actions_for
+from napari_imagej.widgets.widget_utils import _getIcon, python_actions_for
 
 
 class SearcherTreeView(QTreeView):
@@ -107,25 +105,8 @@ class SearchResultItem(QStandardItem):
 
         # Set QtPy properties
         self.setEditable(False)
-        if icon := getIcon(result.iconPath()):
+        if icon := _getIcon(result.iconPath()):
             self.setIcon(icon)
-
-
-@lru_cache
-def getIcon(icon_path):
-    # Ignore falsy paths
-    if not icon_path:
-        return
-    try:
-        # It's tricky to extract files from JARs. So let's get the data as a stream,
-        # write it to a temporary file, and then use THAT file for the icon.
-        stream = jc.File.class_.getResourceAsStream(icon_path)
-        with tempfile.NamedTemporaryFile() as tmp:
-            file = jc.File(ij().py.to_java(tmp.name))
-            jc.Files.copy(stream, file.toPath(), jc.StandardCopyOption.REPLACE_EXISTING)
-            return QIcon(tmp.name)
-    except Exception as e:
-        log_debug(e)
 
 
 class SearchResultModel(QStandardItemModel):

--- a/src/napari_imagej/widgets/result_tree.py
+++ b/src/napari_imagej/widgets/result_tree.py
@@ -4,6 +4,8 @@ A QWidget designed to list SciJava SearchResults.
 SearchResults are grouped by the SciJava Searcher that created them.
 """
 
+from __future__ import annotations
+
 from typing import Dict, List
 
 from qtpy.QtCore import Qt, Signal
@@ -13,7 +15,7 @@ from scyjava import Priority
 
 from napari_imagej.java import ij, jc
 from napari_imagej.utilities.logging import log_debug
-from napari_imagej.widgets.widget_utils import _getIcon, python_actions_for
+from napari_imagej.widgets.widget_utils import _get_icon, python_actions_for
 
 
 class SearcherTreeView(QTreeView):
@@ -106,7 +108,7 @@ class SearchResultItem(QStandardItem):
 
         # Set QtPy properties
         self.setEditable(False)
-        if icon := _getIcon(result.iconPath()):
+        if icon := _get_icon(str(result.iconPath()), result.getClass()):
             self.setIcon(icon)
 
 

--- a/src/napari_imagej/widgets/widget_utils.py
+++ b/src/napari_imagej/widgets/widget_utils.py
@@ -295,26 +295,32 @@ class DetailExportDialog(QDialog):
 
 
 @lru_cache
-def _getIcon(icon_path):
+def _get_icon(path: str, cls: "jc.Class" = None):
     # Ignore falsy paths
-    if not icon_path:
+    if not path:
         return
-    stream = jc.File.class_.getResourceAsStream(icon_path)
-    # Ignore falsy streams
-    if not stream:
+    # Web URLs
+    if path.startswith("https"):
+        # TODO: Add icons from web
         return
-    # Create a buffer to create the byte[]
-    buffer = jc.ByteArrayOutputStream()
-    foo = JArray(JByte)(1024)
-    while True:
-        length = stream.read(foo, 0, foo.length)
-        if length == -1:
-            break
-        buffer.write(foo, 0, length)
-    # Convert the byte[] into a bytearray
-    bytes_array = bytearray()
-    bytes_array.extend(buffer.toByteArray())
-    # Convert thte bytearray into a QIcon
-    pixmap = QPixmap()
-    pixmap.loadFromData(QByteArray(bytes_array))
-    return QIcon(pixmap)
+    # Java Resources
+    elif isinstance(cls, jc.Class):
+        stream = cls.getResourceAsStream(path)
+        # Ignore falsy streams
+        if not stream:
+            return
+        # Create a buffer to create the byte[]
+        buffer = jc.ByteArrayOutputStream()
+        foo = JArray(JByte)(1024)
+        while True:
+            length = stream.read(foo, 0, foo.length)
+            if length == -1:
+                break
+            buffer.write(foo, 0, length)
+        # Convert the byte[] into a bytearray
+        bytes_array = bytearray()
+        bytes_array.extend(buffer.toByteArray())
+        # Convert thte bytearray into a QIcon
+        pixmap = QPixmap()
+        pixmap.loadFromData(QByteArray(bytes_array))
+        return QIcon(pixmap)

--- a/src/napari_imagej/widgets/widget_utils.py
+++ b/src/napari_imagej/widgets/widget_utils.py
@@ -1,10 +1,11 @@
+from functools import lru_cache
 from typing import List
 
 from magicgui import magicgui
 from napari import Viewer
 from napari.layers import Image, Labels, Layer, Points, Shapes
-from qtpy.QtCore import Signal
-from qtpy.QtGui import QFontMetrics
+from qtpy.QtCore import QByteArray, Signal
+from qtpy.QtGui import QFontMetrics, QIcon, QPixmap
 from qtpy.QtWidgets import (
     QApplication,
     QComboBox,
@@ -290,3 +291,22 @@ class DetailExportDialog(QDialog):
             ij().ui().show(j_img)
 
         ij().thread().queue(lambda: pass_to_ij())
+
+
+@lru_cache
+def _getIcon(icon_path):
+    # Ignore falsy paths
+    if not icon_path:
+        return
+    stream = jc.File.class_.getResourceAsStream(icon_path)
+    bytes_array = bytearray()
+    while True:
+        b = stream.read()
+        if b == -1:
+            break
+        bytes_array.append(b)
+
+    pixmap = QPixmap()
+    pixmap.loadFromData(QByteArray(bytes_array))
+
+    return QIcon(pixmap)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -181,6 +181,9 @@ class DummySearchResult(object):
     def iconPath(self):
         return None
 
+    def getClass(self):
+        return None
+
 
 class DummyModuleInfo:
     """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -178,6 +178,9 @@ class DummySearchResult(object):
     def info(self):
         return self._info
 
+    def iconPath(self):
+        return None
+
 
 class DummyModuleInfo:
     """

--- a/tests/widgets/test_result_tree.py
+++ b/tests/widgets/test_result_tree.py
@@ -6,10 +6,11 @@ import pytest
 from qtpy.QtCore import QRunnable, Qt, QThreadPool
 from qtpy.QtWidgets import QApplication, QMenu
 
+from napari_imagej.java import init_ij
 from napari_imagej.widgets.result_tree import (
-    SearcherTreeItem,
-    SearchResultTree,
-    SearchResultTreeItem,
+    SearcherItem,
+    SearcherTreeView,
+    SearchResultItem,
 )
 from napari_imagej.widgets.widget_utils import python_actions_for
 from tests.utils import DummySearcher, DummySearchEvent, DummySearchResult
@@ -18,71 +19,69 @@ from tests.widgets.widget_utils import _populate_tree
 
 @pytest.fixture
 def results_tree():
-    return SearchResultTree(None)
+    return SearcherTreeView(None)
 
 
 @pytest.fixture
 def fixed_tree(ij, asserter):
     """Creates a "fake" ResultsTree with deterministic results"""
     # Create a default SearchResultTree
-    tree = SearchResultTree(None)
+    tree = SearcherTreeView(None)
     _populate_tree(tree, asserter)
 
     return tree
 
 
-def test_results_widget_layout(fixed_tree: SearchResultTree):
+def test_results_widget_layout(fixed_tree: SearcherTreeView):
     """Tests the number and expected order of results widget children"""
-    assert fixed_tree.columnCount() == 1
-    assert fixed_tree.headerItem().text(0) == "Search"
+    assert fixed_tree.model().columnCount() == 1
+    assert fixed_tree.model().headerData(0, Qt.Horizontal, 0) == "Search"
 
 
-def test_arrow_key_selection(fixed_tree: SearchResultTree, qtbot, asserter):
-    # Start by selecting the first item in the tree
-    fixed_tree.setCurrentItem(fixed_tree.topLevelItem(0))
-    asserter(lambda: fixed_tree.currentItem() is fixed_tree.topLevelItem(0))
+def test_arrow_key_selection(fixed_tree: SearcherTreeView, qtbot, asserter):
+    idx = fixed_tree.model().index(0, 0)
+    fixed_tree.setCurrentIndex(idx)
+    asserter(lambda: fixed_tree.currentIndex() == idx)
     # HACK: For some reason, they are not expanded in the tests!
-    fixed_tree.topLevelItem(0).setExpanded(True)
-    for i in range(3):
-        qtbot.keyPress(fixed_tree, Qt.Key_Down)
-        asserter(
-            lambda: fixed_tree.currentItem() is fixed_tree.topLevelItem(0).child(i)
-        )
-    qtbot.keyPress(fixed_tree, Qt.Key_Down)
-    asserter(lambda: fixed_tree.currentItem() is fixed_tree.topLevelItem(1))
-    # HACK: For some reason, they are not expanded in the tests!
-    fixed_tree.topLevelItem(1).setExpanded(True)
+    fixed_tree.setExpanded(idx, True)
     for i in range(2):
         qtbot.keyPress(fixed_tree, Qt.Key_Down)
-        asserter(
-            lambda: fixed_tree.currentItem() is fixed_tree.topLevelItem(1).child(i)
-        )
+        asserter(lambda: fixed_tree.currentIndex() == idx.child(i, 0))
     qtbot.keyPress(fixed_tree, Qt.Key_Down)
-    asserter(lambda: fixed_tree.currentItem() is fixed_tree.topLevelItem(1).child(1))
+    idx = idx.sibling(idx.row() + 1, 0)
+    asserter(lambda: fixed_tree.currentIndex() == idx)
+    # HACK: For some reason, they are not expanded in the tests!
+    fixed_tree.setExpanded(idx, True)
+    for i in range(3):
+        qtbot.keyPress(fixed_tree, Qt.Key_Down)
+        asserter(lambda: fixed_tree.currentIndex() == idx.child(i, 0))
+    qtbot.keyPress(fixed_tree, Qt.Key_Down)
+    asserter(lambda: fixed_tree.currentIndex() == idx.child(2, 0))
 
 
-def test_searchers_persist(fixed_tree: SearchResultTree, asserter):
+def test_searchers_persist(fixed_tree: SearcherTreeView, asserter):
     # Find the first searcher, and remove its children
-    searcher = fixed_tree.topLevelItem(0)._searcher
-    asserter(lambda: fixed_tree.topLevelItem(0).childCount() > 0)
-    fixed_tree.process.emit(DummySearchEvent(searcher, []))
+    item = fixed_tree.model().invisibleRootItem().child(0, 0)
+    searcher = item.searcher
+    asserter(lambda: item.rowCount() > 0)
+    fixed_tree.model().process.emit(DummySearchEvent(searcher, []))
     # Ensure that the children disappear, but the searcher remains
-    asserter(lambda: fixed_tree.topLevelItem(0).childCount() == 0)
-    asserter(lambda: fixed_tree.topLevelItemCount() == 2)
-    asserter(lambda: not fixed_tree.topLevelItem(0).isExpanded())
+    asserter(lambda: item.rowCount() == 0)
+    asserter(lambda: fixed_tree.model().invisibleRootItem().rowCount() == 2)
 
 
 def test_resultTreeItem_regression():
     dummy = DummySearchResult()
-    item = SearchResultTreeItem(dummy)
+    item = SearchResultItem(dummy)
     assert item.result == dummy
-    assert item.text(0) == dummy.name()
+    assert item.data(0) == dummy.name()
 
 
 def test_searcherTreeItem_regression():
+    init_ij()
     dummy = DummySearcher("This is not a Searcher")
-    item = SearcherTreeItem(dummy)
-    assert item._searcher == dummy
+    item = SearcherItem(dummy)
+    assert item.searcher == dummy
     assert (
         item.flags()
         == Qt.ItemIsUserCheckable
@@ -90,66 +89,67 @@ def test_searcherTreeItem_regression():
         | Qt.ItemIsDragEnabled
         | Qt.ItemIsDropEnabled
     )
-    assert item.text(0) == dummy.title()
+    assert item.data(0) == dummy.title()
 
 
-def test_arrow_key_expansion(fixed_tree: SearchResultTree, qtbot, asserter):
-    fixed_tree.setCurrentItem(fixed_tree.topLevelItem(0))
-    expanded = fixed_tree.currentItem().isExpanded()
+def test_arrow_key_expansion(fixed_tree: SearcherTreeView, qtbot, asserter):
+    idx = fixed_tree.model().index(0, 0)
+    fixed_tree.setCurrentIndex(idx)
+    expanded = fixed_tree.isExpanded(idx)
     # Part 1: toggle with Enter
     qtbot.keyPress(fixed_tree, Qt.Key_Return)
-    assert fixed_tree.currentItem().isExpanded() is not expanded
+    assert fixed_tree.isExpanded(idx) is not expanded
     qtbot.keyPress(fixed_tree, Qt.Key_Return)
-    assert fixed_tree.currentItem().isExpanded() is expanded
+    assert fixed_tree.isExpanded(idx) is expanded
     # Part 2: test arrow keys
-    fixed_tree.currentItem().setExpanded(True)
+    fixed_tree.setExpanded(idx, True)
     # Part 2.1: Expanded + Left hides children
     qtbot.keyPress(fixed_tree, Qt.Key_Left)
-    assert fixed_tree.currentItem().isExpanded() is False
+    assert fixed_tree.isExpanded(idx) is False
     # Part 2.2: Hidden + Right shows children
     qtbot.keyPress(fixed_tree, Qt.Key_Right)
-    assert fixed_tree.currentItem().isExpanded() is True
+    assert fixed_tree.isExpanded(idx) is True
     # Part 2.3: Expanded + Right selects first child
-    parent = fixed_tree.currentItem()
     qtbot.keyPress(fixed_tree, Qt.Key_Right)
-    asserter(lambda: fixed_tree.currentItem() is parent.child(0))
+    asserter(
+        lambda: fixed_tree.currentIndex().row() == 0
+        and fixed_tree.currentIndex().parent() == idx
+    )
     # Part 2.4: Child + Left returns to parent
     qtbot.keyPress(fixed_tree, Qt.Key_Left)
-    asserter(lambda: fixed_tree.currentItem() is parent)
+    asserter(lambda: fixed_tree.currentIndex() == idx)
 
 
-def test_search_tree_disable(fixed_tree: SearchResultTree, asserter):
+def test_search_tree_disable(fixed_tree: SearcherTreeView, asserter):
     # Grab an arbitratry enabled Searcher
-    searcher_item = fixed_tree.topLevelItem(0)
+    item = fixed_tree.model().invisibleRootItem().child(1, 0)
     # Assert GUI start
-    asserter(lambda: searcher_item.text(0) == searcher_item._searcher.title() + " (3)")
-    asserter(lambda: searcher_item.checkState(0) == Qt.Checked)
-    asserter(lambda: searcher_item.isExpanded())
+    asserter(lambda: item.data(0) == "Test2 (3)")
+    asserter(lambda: item.checkState() == Qt.Checked)
 
     # Disable the searcher, assert the proper GUI response
-    searcher_item.setCheckState(0, Qt.Unchecked)
-    asserter(lambda: searcher_item.text(0) == searcher_item._searcher.title())
-    asserter(lambda: not searcher_item.isExpanded())
-    asserter(lambda: searcher_item.childCount() == 0)
+    item.setCheckState(Qt.Unchecked)
+    asserter(lambda: item.data(0) == "Test2")
+    asserter(lambda: item.rowCount() == 0)
 
     # Enable the searcher, assert the proper GUI response
-    searcher_item.setCheckState(0, Qt.Checked)
-    asserter(lambda: searcher_item.text(0) == searcher_item._searcher.title())
-    asserter(lambda: not searcher_item.isExpanded())
-    asserter(lambda: searcher_item.childCount() == 0)
+    item.setCheckState(Qt.Checked)
+    asserter(lambda: item.data(0) == "Test2")
+    asserter(lambda: item.rowCount() == 0)
 
 
-def test_right_click(fixed_tree: SearchResultTree, asserter):
+def test_right_click(fixed_tree: SearcherTreeView, asserter):
     """
-    Ensures that SearchResultTree has a CustomContextMenuPolicy,
+    Ensures that SearcherTreeView has a CustomContextMenuPolicy,
     creating a menu that has the SciJava Search Actions relevant for
     an arbitrary SearchResult
     """
     # First, assert the policy
     assert fixed_tree.contextMenuPolicy() == Qt.CustomContextMenu
     # Then, grab an arbitratry Search Result
-    item = fixed_tree.topLevelItem(0).child(0)
-    rect = fixed_tree.visualItemRect(item)
+    idx = fixed_tree.model().index(0, 0).child(0, 0)
+    rect = fixed_tree.visualRect(idx)
+    item = fixed_tree.model().itemFromIndex(idx)
     # Find its SearchActions
     expected_action_names = [pair[0] for pair in python_actions_for(item.result, None)]
 

--- a/tests/widgets/test_result_tree.py
+++ b/tests/widgets/test_result_tree.py
@@ -85,6 +85,7 @@ def test_searcherTreeItem_regression():
     assert (
         item.flags()
         == Qt.ItemIsUserCheckable
+        | Qt.ItemIsSelectable
         | Qt.ItemIsEnabled
         | Qt.ItemIsDragEnabled
         | Qt.ItemIsDropEnabled

--- a/tests/widgets/test_result_tree.py
+++ b/tests/widgets/test_result_tree.py
@@ -92,32 +92,15 @@ def test_searcherTreeItem_regression():
     assert item.data(0) == dummy.title()
 
 
-def test_arrow_key_expansion(fixed_tree: SearcherTreeView, qtbot, asserter):
+def test_key_return_expansion(fixed_tree: SearcherTreeView, qtbot, asserter):
     idx = fixed_tree.model().index(0, 0)
     fixed_tree.setCurrentIndex(idx)
     expanded = fixed_tree.isExpanded(idx)
-    # Part 1: toggle with Enter
+    # Toggle with enter
     qtbot.keyPress(fixed_tree, Qt.Key_Return)
     assert fixed_tree.isExpanded(idx) is not expanded
     qtbot.keyPress(fixed_tree, Qt.Key_Return)
     assert fixed_tree.isExpanded(idx) is expanded
-    # Part 2: test arrow keys
-    fixed_tree.setExpanded(idx, True)
-    # Part 2.1: Expanded + Left hides children
-    qtbot.keyPress(fixed_tree, Qt.Key_Left)
-    assert fixed_tree.isExpanded(idx) is False
-    # Part 2.2: Hidden + Right shows children
-    qtbot.keyPress(fixed_tree, Qt.Key_Right)
-    assert fixed_tree.isExpanded(idx) is True
-    # Part 2.3: Expanded + Right selects first child
-    qtbot.keyPress(fixed_tree, Qt.Key_Right)
-    asserter(
-        lambda: fixed_tree.currentIndex().row() == 0
-        and fixed_tree.currentIndex().parent() == idx
-    )
-    # Part 2.4: Child + Left returns to parent
-    qtbot.keyPress(fixed_tree, Qt.Key_Left)
-    asserter(lambda: fixed_tree.currentIndex() == idx)
 
 
 def test_search_tree_disable(fixed_tree: SearcherTreeView, asserter):

--- a/tests/widgets/test_result_tree.py
+++ b/tests/widgets/test_result_tree.py
@@ -38,27 +38,6 @@ def test_results_widget_layout(fixed_tree: SearcherTreeView):
     assert fixed_tree.model().headerData(0, Qt.Horizontal, 0) == "Search"
 
 
-def test_arrow_key_selection(fixed_tree: SearcherTreeView, qtbot, asserter):
-    idx = fixed_tree.model().index(0, 0)
-    fixed_tree.setCurrentIndex(idx)
-    asserter(lambda: fixed_tree.currentIndex() == idx)
-    # HACK: For some reason, they are not expanded in the tests!
-    fixed_tree.setExpanded(idx, True)
-    for i in range(2):
-        qtbot.keyPress(fixed_tree, Qt.Key_Down)
-        asserter(lambda: fixed_tree.currentIndex() == idx.child(i, 0))
-    qtbot.keyPress(fixed_tree, Qt.Key_Down)
-    idx = idx.sibling(idx.row() + 1, 0)
-    asserter(lambda: fixed_tree.currentIndex() == idx)
-    # HACK: For some reason, they are not expanded in the tests!
-    fixed_tree.setExpanded(idx, True)
-    for i in range(3):
-        qtbot.keyPress(fixed_tree, Qt.Key_Down)
-        asserter(lambda: fixed_tree.currentIndex() == idx.child(i, 0))
-    qtbot.keyPress(fixed_tree, Qt.Key_Down)
-    asserter(lambda: fixed_tree.currentIndex() == idx.child(2, 0))
-
-
 def test_searchers_persist(fixed_tree: SearcherTreeView, asserter):
     # Find the first searcher, and remove its children
     item = fixed_tree.model().invisibleRootItem().child(0, 0)


### PR DESCRIPTION
This PR converts the search result `QTreeWidget` to use Qt's [model/view](https://doc.qt.io/qt-6/model-view-programming.html) paradigm - not only is this a better separation of concerns, but it also makes it easier to do things like adding icons to search results.

