### PR TITLE
Bump various versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        # NB: [3.11.0, 3.11.2] do not have arm64 macos support
-        python-version: ['3.8', '3.11.3']
+        python-version: ['3.8', '3.12']
 
     steps:
       - uses: actions/checkout@v2

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -18,16 +18,16 @@ name: napari-imagej-dev
 channels:
   - conda-forge
 dependencies:
-  - python >= 3.8, <3.12
+  - python >= 3.8, < 3.13
   # Project dependencies
-  - confuse
+  - confuse >= 2.0.0
   - imglyb >= 2.1.0
   - jpype1 >= 1.4.1
   - labeling >= 0.1.12
   - magicgui >= 0.5.1
-  - napari >= 0.4.17, <0.5
+  - napari >= 0.4.17
   - numpy
-  - openjdk=8
+  - openjdk=11
   - pandas
   - pyimagej >= 1.4.1
   - scyjava >= 1.8.1

--- a/environment.yml
+++ b/environment.yml
@@ -18,16 +18,16 @@ name: napari-imagej
 channels:
   - conda-forge
 dependencies:
-  - python >= 3.8, < 3.12
+  - python >= 3.8, < 3.13
   # Project depenencies
-  - confuse
+  - confuse >= 2.0.0
   - imglyb >= 2.1.0
   - jpype1 >= 1.4.1
   - labeling >= 0.1.12
   - magicgui >= 0.5.1
-  - napari >= 0.4.17, <0.5
+  - napari >= 0.4.17
   - numpy
-  - openjdk=8
+  - openjdk=11
   - pandas
   - pyimagej >= 1.4.1
   - scyjava >= 1.8.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,14 +32,14 @@ classifiers = [
 ]
 
 # NB: Keep this in sync with environment.yml AND dev-environment.yml!
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.8, <3.13"
 dependencies = [
-    "confuse",
+    "confuse >= 2.0.0",
     "imglyb >= 2.1.0",
     "jpype1 >= 1.4.1",
     "labeling >= 0.1.12",
     "magicgui >= 0.5.1",
-    "napari >= 0.4.17, <0.5",
+    "napari >= 0.4.17",
     "numpy",
     "pandas",
     "pyimagej >= 1.4.1",

--- a/tests/widgets/test_napari_imagej.py
+++ b/tests/widgets/test_napari_imagej.py
@@ -41,16 +41,16 @@ def test_widget_subwidget_layout(imagej_widget: NapariImageJWidget):
 def test_keymaps(make_napari_viewer, qtbot):
     """Tests that 'Ctrl+L' is added to the keymap by ImageJWidget"""
 
-    def find_keybind(kb: str) -> bool:
+    def find_keybind(kbs) -> bool:
         for k, _ in viewer.keymap.items():
-            if str(k) == kb:
+            if str(k) in kbs:
                 return True
         return False
 
     viewer: Viewer = make_napari_viewer()
-    assert not find_keybind("Control-L")
+    assert not find_keybind(["Control-L", "Ctrl+L"])
     NapariImageJWidget(viewer)
-    assert find_keybind("Control-L")
+    assert find_keybind(["Control-L", "Ctrl+L"])
     # TODO: I can't seem to figure out how to assert that pressing 'L'
     # sets the focus of the search bar.
     # Typing viewer.keymap['L'](viewer) does nothing. :(


### PR DESCRIPTION
This PR increases various versions underpinning napari-imagej:
* Python - 3.12 is now enabled
* Confuse - 2.0.0+ is now required
* OpenJDK - 11+ is now required
* naparir - 0.5.0+ is now enabled