### PR TITLE
Add widgets for Java Number implementations

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -31,6 +31,7 @@ dependencies:
   - pandas
   - pyimagej >= 1.4.1
   - scyjava >= 1.8.1
+  - xarray < 2024.10.0
   # Version rules to avoid problems
   - qtconsole != 5.4.2
   - typing_extensions != 4.6.0

--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,7 @@ dependencies:
   - pandas
   - pyimagej >= 1.4.1
   - scyjava >= 1.8.1
+  - xarray < 2024.10.0
   # Version rules to avoid problems
   - qtconsole != 5.4.2
   - typing_extensions != 4.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pandas",
     "pyimagej >= 1.4.1",
     "scyjava >= 1.9.1",
+    "xarray < 2024.10.0",
     # Version rules to avoid problems
     "qtconsole != 5.4.2", # https://github.com/napari/napari/issues/5700
     "typing_extensions != 4.6.0", # https://github.com/pydantic/pydantic/issues/5821

--- a/src/napari_imagej/types/widget_mappings.py
+++ b/src/napari_imagej/types/widget_mappings.py
@@ -15,6 +15,7 @@ from napari_imagej.java import jc
 from napari_imagej.widgets.parameter_widgets import (
     ShapeWidget,
     file_widget_for,
+    number_widget_for,
     numeric_type_widget_for,
 )
 
@@ -69,6 +70,14 @@ def _numeric_type_preference(
 ) -> Optional[Union[type, str]]:
     if issubclass(item.getType(), jc.NumericType):
         return numeric_type_widget_for(item.getType())
+
+
+@_widget_preference
+def _number_preference(
+    item: "jc.ModuleItem", type_hint: Union[type, str]
+) -> Optional[Union[type, str]]:
+    if issubclass(item.getType(), jc.Number):
+        return number_widget_for(item.getType())
 
 
 @_widget_preference

--- a/tests/utilities/test_module_utils.py
+++ b/tests/utilities/test_module_utils.py
@@ -248,7 +248,6 @@ def test_add_scijava_metadata(metadata_module_item: DummyModuleItem):
     assert param_map["label"] == "bar"
     assert param_map["tooltip"] == "The foo."
     assert param_map["choices"] == ["a", "b", "c"]
-    assert param_map["widget_type"] == "FloatSpinBox"
 
 
 choiceList = [

--- a/tests/widgets/test_parameter_widgets.py
+++ b/tests/widgets/test_parameter_widgets.py
@@ -19,6 +19,7 @@ from magicgui.widgets import (
 )
 from napari import current_viewer
 from napari.layers import Image
+from scyjava import numeric_bounds
 
 from napari_imagej.widgets.parameter_widgets import (
     DirectoryWidget,
@@ -26,6 +27,7 @@ from napari_imagej.widgets.parameter_widgets import (
     OpenFileWidget,
     SaveFileWidget,
     ShapeWidget,
+    number_widget_for,
     numeric_type_widget_for,
 )
 from tests.utils import jc
@@ -162,6 +164,32 @@ def test_mutable_output_add_new_image(
     assert foo in input_widget.choices
     assert foo in output_widget.choices
     assert foo is output_widget.value
+
+
+def test_numbers(ij):
+    numbers = [
+        jc.Byte,
+        jc.Short,
+        jc.Integer,
+        jc.Long,
+        jc.Float,
+        jc.Double,
+        jc.BigInteger,
+        jc.BigDecimal,
+    ]
+    for number in numbers:
+        # NB See HACK in number_widget_for
+        if number == jc.BigInteger:
+            min_val, max_val = numeric_bounds(jc.Long)
+        elif number == jc.BigDecimal:
+            min_val, max_val = numeric_bounds(jc.Double)
+        else:
+            min_val, max_val = numeric_bounds(number)
+
+        widget = number_widget_for(number.class_)()
+        assert min_val == widget.min
+        assert max_val == widget.max
+        assert isinstance(widget.value, number)
 
 
 def test_realType():


### PR DESCRIPTION
Specifically, this PR adds a set of parameter widgets for each `Number` implementation. These widgets are direct subclasses of `magicgui`'s `FloatSpinBox`/`SpinBox`, but with the range bounded by the range of the Java type (they additionally wrap the returned programmatic value into a Java type).

Closes #276 
