### PR TITLE
Attach Points as ROI in Data Translation

### DIFF
--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -37,9 +37,9 @@ recommended_versions = {
     # Versions above are easier for inclusion of scifio-labeling
     # https://github.com/imagej/pyimagej/issues/280
     "net.imagej:imagej": "2.10.0",
-    # Enable visualizing Datasets with DefaultROITrees
-    # https://github.com/imagej/imagej-legacy/pull/300
-    "net.imagej:imagej-legacy": "1.2.1",
+    # Removes ClassCastExceptions in Point layer translation
+    # https://github.com/imagej/imagej-legacy/pull/310
+    "net.imagej:imagej-legacy": "2.0.0",
     # Enables threshold Ops to return Images of BooleanTypes
     # https://github.com/imagej/imagej-ops/pull/651
     "net.imagej:imagej-ops": "2.0.1",

--- a/src/napari_imagej/widgets/widget_utils.py
+++ b/src/napari_imagej/widgets/widget_utils.py
@@ -299,7 +299,13 @@ class DetailExportDialog(QDialog):
                 img, dim_order=self.dims_container.provided_labels()
             )
             if roi:
-                j_img.getProperties().put("rois", nij.ij.py.to_java(roi))
+                if isinstance(roi, Points):
+                    j_point = nij.ij.py.to_java(roi)
+                    j_roi = jc.DefaultROITree()
+                    j_roi.addROIs(jc.ArrayList([j_point]))
+                else:
+                    j_roi = nij.ij.py.to_java(roi)
+                j_img.getProperties().put("rois", j_roi)
             # Show the resulting image
             nij.ij.ui().show(j_img)
 


### PR DESCRIPTION
This PR ensures that napari `Points` layers are wrapped up into a `ROITree` when being passed to ImageJ/Fiji.

This PR was separated from #305, and is still a draft, because it causes `ClassCastExceptions` arising from imagej/imagej-legacy#299. We should wait for the fix in imagej/imagej-legacy#310 to be merged and released, before merging this.