### PR TITLE
Update Use Cases to 0.2.0

### DIFF
--- a/doc/examples/bonej.rst
+++ b/doc/examples/bonej.rst
@@ -3,12 +3,22 @@ Using BoneJ2
 
 Here we adapt a workflow from `the BoneJ2 paper <https://wellcomeopenresearch.org/articles/6-37>`_ for use with napari-imagej.
 
+.. important::
+
+    This Use Case was run with the following Mamba environment::
+
+        mamba env create -n ex-bonej -y -c conda-forge python=3.10 openjdk=11.0 napari=0.5.0 napari-imagej=0.2.0 napari-segment-blobs-and-things-with-membranes=0.3.11
+
+    and napari-imagej was configured to use the following endpoint::
+        
+        sc.fiji:fiji:2.15.0+org.bonej:bonej-ops:MANAGED+org.bonej:bonej-plugins:MANAGED+org.bonej:bonej-utilities:MANAGED
+
 napari Setup
 ------------
 
 We will install one additional napari plugin, `napari-segment-blobs-and-things-with-membranes <https://github.com/haesleinhuepf/napari-segment-blobs-and-things-with-membranes>`_, to support this use case. Instructions for finding and installing a napari plugin are `here <https://napari.org/stable/plugins/find_and_install_plugin.html>`__
 
-To install ``napari-segment-blobs-and-things-with-membranes``, simply ensure that your napari environment is active and paste the following into your terminal:
+If you did not use the above Mamba environment, you can install ``napari-segment-blobs-and-things-with-membranes`` by ensuring that your napari environment is active and pasting the following into your terminal:
 
 .. code-block:: bash
 
@@ -19,13 +29,13 @@ Once the plugin has been installed correctly, ``napari-segment-blobs-and-things-
 BoneJ2 Setup
 ------------
 
-We need to first specify the endpoint that we will use to access BoneJ2.
+We now need to first specify the endpoint that we will use to access BoneJ2.
 
-We can configure napari-imagej to use BoneJ2 by opening the settings dialog and changing the ``imagej directory or endpoint`` (described `here <../Configuration.html#imagej-directory-or-endpoint>`__). Within the napari-imagej settings dialog, paste the following into the ``imagej directory or endpoint`` field, and click ``OK``:
+We can configure napari-imagej to use BoneJ2 by opening the settings dialog and changing the ``imagej directory or endpoint`` (described `here <../Configuration.html#imagej-directory-or-endpoint>`__). Within the napari-imagej settings dialog paste the following into the ``imagej directory or endpoint`` field, and click ``OK``:
 
 .. code-block::
 
-    sc.fiji:fiji:2.13.0+org.bonej:bonej-ops:MANAGED+org.bonej:bonej-plugins:MANAGED+org.bonej:bonej-utilities:MANAGED
+    sc.fiji:fiji:2.15.0+org.bonej:bonej-ops:MANAGED+org.bonej:bonej-plugins:MANAGED+org.bonej:bonej-utilities:MANAGED
 
 
 **Note that napari must be restarted for these changes to take effect!**
@@ -125,6 +135,10 @@ This will output the fractal dimension of the image.
 .. figure:: https://media.imagej.net/napari-imagej/0.2.0/bonej2_fractal_dimension.png
 
             Setting the parameters of BoneJ2's fractal dimension command.
+
+.. note::
+
+    If you make any mistakes in executing these commands, including passing the wrong image, the results table will record additional rows. When this happens, know that the lowest non- ``nan`` row has the correct output. See the issue on GitHub `here <https://github.com/imagej/napari-imagej/issues/310>`_\.
 
 
 **Calculating the surface area:**

--- a/doc/examples/ops.rst
+++ b/doc/examples/ops.rst
@@ -3,6 +3,16 @@ Image Processing with ImageJ Ops (headless)
 
 The `ImageJ Ops`_ project contains hundreds of algorithms for module image processing, and is shipped with every ImageJ2 installation. This document explains how to use ImageJ Ops from the napari interface.
 
+.. important::
+
+    This Use Case was run with the following Mamba environment::
+
+        mamba env create -n ex-ops -y -c conda-forge python=3.11 openjdk=11.0 napari=0.5.0 napari-imagej=0.2.0
+
+    and napari-imagej was configured to use the following endpoint::
+        
+        net.imagej:imagej:2.15.0
+
 Ops, explained
 --------------
 

--- a/doc/examples/scripting.rst
+++ b/doc/examples/scripting.rst
@@ -9,12 +9,22 @@ For this example, we translated PyImageJ's `Puncta Segmentation`_ into a SciJava
 
 For more information on the use case itself, please see the original PyImageJ Puncta Segmentation example.
 
+.. important::
+
+    This Use Case was run with the following Mamba environment::
+
+        mamba env create -n ex-segment -y -c conda-forge python=3.11 openjdk=11.0 napari=0.5.0 napari-imagej=0.2.0
+
+    and napari-imagej was configured to use the following endpoint::
+        
+        net.imagej:imagej:2.15.0
+
 Configuration
 -------------
 
 To run this use case, the following settings were used. For information on configuring napari-imagej, please see `here <../Configuration.html>`__.
 
-.. figure:: https://media.imagej.net/napari-imagej/0.2.0/settings_fiji.png
+.. figure:: https://media.imagej.net/napari-imagej/0.2.0/settings_imagej_2.15.0.png
 
     Configuration for the Puncta Segmentation use case
 
@@ -112,7 +122,7 @@ The second step is to find our script within napari-imagej. Discovered SciJava S
 
 .. figure:: https://media.imagej.net/napari-imagej/0.2.0/puncta_search.png
     
-    ``Puncta_Segmentation.py`` exposed within the napari-imagej searchbar as ``PunctaSegmentation``.
+    ``Puncta_Segmentation.py`` exposed within the napari-imagej searchbar as ``Puncta Segmentation``.
 
 Double-clicking on ``PunctaSegmentation`` will bring a modal dialog, prompting the user for input data. The dialog also offers to display the resulting table in a new window, which may be preferred for large result tables.
 

--- a/doc/examples/trackmate.rst
+++ b/doc/examples/trackmate.rst
@@ -11,6 +11,16 @@ For this use case we will analyze `live cell wide-field microscopy data of HeLa 
 
 |
 
+.. important::
+
+    This Use Case was run with the following Mamba environment::
+
+        mamba env create -n ex-tracking -y -c conda-forge python=3.11 openjdk=11.0 napari=0.5.0 napari-imagej=0.2.0 napari-stracking=0.1.9
+
+    and napari-imagej was configured to use the following endpoint::
+        
+        sc.fiji:fiji:2.15.0
+
 TrackMate Setup
 ---------------
 
@@ -24,7 +34,7 @@ We can configure napari-imagej to use a `Fiji`_ installation as follows:
 
 2. Open the settings dialog by clicking the rightmost toolbar button, the gear symbol.
 
-3. Change the ``ImageJ directory or endpoint`` (described `here <../Configuration.html#imagej-directory-or-endpoint>`_) to include Fiji, which bundles many popular plugins including TrackMate. This example was created using an endpoint of ``sc.fiji:fiji:2.13.1``.
+3. Change the ``ImageJ directory or endpoint`` (described `here <../Configuration.html#imagej-directory-or-endpoint>`_) to include Fiji, which bundles many popular plugins including TrackMate. Change this setting to the napari-imagej endpoint listed above.
 
 .. figure:: https://media.imagej.net/napari-imagej/0.2.0/settings_fiji.png
 
@@ -98,7 +108,7 @@ Once the spots and tracks have been generated, you can return to napari and use 
 Processing tracks with napari-stracking
 ---------------------------------------
 
-While the `napari-stracking`_ plugin is capable of performing its own particle tracking, it also comes with some track processing tools. We can install ``napari-stracking`` through the following steps:
+While the `napari-stracking`_ plugin is capable of performing its own particle tracking, it also comes with some track processing tools. If you did not install ``napari-stracking`` while setting up your environment, you can install ``napari-stracking`` through the following steps:
 
 1. Open the plugin installation window by selecting ``Plugins>Install/Uninstall Plugins...`` from the napari menu
 

--- a/doc/examples/trackmate_reader.rst
+++ b/doc/examples/trackmate_reader.rst
@@ -5,6 +5,46 @@ The `TrackMate <https://imagej.net/plugins/trackmate/>`_ plugin for ImageJ2 prov
 
 **Note:** TrackMate is not included by default with ImageJ. To set up napari-imagej with TrackMate, see `these instructions <./trackmate.html#trackmate-plugin-setup>`_.
 
+.. important::
+
+    This Use Case was run with the following Mamba environment::
+
+        mamba env create -n ex-track-read -y -c conda-forge python=3.11 openjdk=11.0 napari=0.5.0 napari-imagej=0.2.0
+
+    and napari-imagej was configured to use the following endpoint::
+        
+        sc.fiji:fiji:2.15.0
+
+TrackMate Setup
+---------------
+
+By default, napari-imagej does not include TrackMate. To use the TrackMate plugin, we must first configure napari-imagej to enable TrackMate access.
+
+We can configure napari-imagej to use a `Fiji`_ installation as follows:
+
+.. |ImageJ2| image:: ../../src/napari_imagej/resources/imagej2-16x16-flat.png
+
+1. Activate the napari-imagej plugin by selecting the ``ImageJ2`` plugin from the Plugins menu.
+
+2. Open the settings dialog by clicking the rightmost toolbar button, the gear symbol.
+
+3. Change the ``ImageJ directory or endpoint`` (described `here <../Configuration.html#imagej-directory-or-endpoint>`_) to include Fiji, which bundles many popular plugins including TrackMate. Change this setting to the napari-imagej endpoint listed above.
+
+.. figure:: https://media.imagej.net/napari-imagej/0.2.0/settings_fiji.png
+
+4. **Restart napari** for the changes to take effect.
+
+5. Activate the napari-imagej plugin again, as described in step (1) above.
+
+6. If you wish, you may verify that Fiji is enabled by pasting the following code into napari's IPython console:
+
+.. code-block:: python
+
+   from napari_imagej.java import _ij as ij
+   ij.app().getApps().keys()
+
+And if ``Fiji`` is in the list, you're good!
+
 TrackMate XML
 -------------
 
@@ -27,7 +67,7 @@ You will need to download two files:
 Opening the data
 -------------------
 
-Once napari is running, you can open the data within napari through ``File>Open File(s)...``, and selecting both the ``.tif`` and ``.xml`` sample files that were downloaded.
+Once napari is running, you can open the data within napari through ``File>Open File(s)...``, and selecting the ``.xml`` sample file that was downloaded.
 
 There might be a slight delay while the files open. This process can be an expensive operation as we require a running JVM and conversion of the TrackMate ``Model`` into napari ``Layers``; however, the reader plugin displays a progress bar in the ``Activity`` pane.
 
@@ -35,3 +75,5 @@ When complete, you should see the image, track and label layers in napari:
 
 .. figure:: https://media.imagej.net/napari-imagej/0.2.0/trackmate_reader.gif
     :align: center
+
+.. _Fiji: https://fiji.sc/


### PR DESCRIPTION
This PR updates all of the Use Cases with new graphics that reflect UI updates, but perhaps more importantly, they provide new admonitions at the start of each use case describing:
* The exact Mamba environment used
* The PyImageJ endpoint used
![image](https://github.com/user-attachments/assets/8b1fe16b-36a4-40fd-868c-903ff0b4556a)

