### PR TITLE
New image, v2

### DIFF
--- a/src/napari_imagej/types/converters/images.py
+++ b/src/napari_imagej/types/converters/images.py
@@ -78,9 +78,17 @@ def _image_layer_to_dataset(image: Image, **kwargs) -> "jc.Dataset":
     :param image: a napari Image layer
     :return: a Dataset
     """
-    # Define dimension order if necessary
+    # Redefine dimension order if necessary
     data = image.data
-    if not hasattr(data, "dims") and "dim_order" not in kwargs:
+    if hasattr(data, "dims"):
+        if "dim_order" in kwargs:
+            dim_remapping = {
+                old: new for old, new in zip(data.dims, kwargs["dim_order"])
+            }
+            data = data.rename(dim_remapping)
+            kwargs.pop("dim_order")
+    # Define dimension order if necessary
+    elif "dim_order" not in kwargs:
         # NB "dim_i"s will be overwritten later
         dim_order = [f"dim_{i}" for i in range(len(data.shape))]
         # if RGB, last dimension is Channel

--- a/src/napari_imagej/types/converters/images.py
+++ b/src/napari_imagej/types/converters/images.py
@@ -79,9 +79,10 @@ def _image_layer_to_dataset(image: Image, **kwargs) -> "jc.Dataset":
     :return: a Dataset
     """
     # Define dimension order if necessary
-    if "dim_order" not in kwargs:
+    data = image.data
+    if not hasattr(data, "dims") and "dim_order" not in kwargs:
         # NB "dim_i"s will be overwritten later
-        dim_order = [f"dim_{i}" for i in range(len(image.data.shape))]
+        dim_order = [f"dim_{i}" for i in range(len(data.shape))]
         # if RGB, last dimension is Channel
         if image.rgb:
             dim_order[-1] = "Channel"
@@ -89,7 +90,7 @@ def _image_layer_to_dataset(image: Image, **kwargs) -> "jc.Dataset":
         kwargs["dim_order"] = dim_order
 
     # Construct a dataset from the data
-    dataset: "jc.Dataset" = nij.ij.py.to_dataset(image.data, **kwargs)
+    dataset: "jc.Dataset" = nij.ij.py.to_dataset(data, **kwargs)
 
     # Clean up the axes
     axes = [

--- a/src/napari_imagej/widgets/parameter_widgets.py
+++ b/src/napari_imagej/widgets/parameter_widgets.py
@@ -379,6 +379,12 @@ class MutableOutputWidget(Container):
             import numpy as np
             import xarray
 
+            dims = tuple(p[1] for p in params["shape"])
+            # Ensure every dimension is unique
+            if len(dims) != len(set(dims)):
+                # TODO: Ideally this would be prevented in the widget
+                raise ValueError("Cannot have repeated dimensions")
+
             data = xarray.DataArray(
                 data=np.full(
                     shape=tuple(p[0] for p in params["shape"]),

--- a/src/napari_imagej/widgets/parameter_widgets.py
+++ b/src/napari_imagej/widgets/parameter_widgets.py
@@ -45,8 +45,8 @@ CONVENTIONAL_DIMS = [
     ["X"],
     ["Y", "X"],
     ["Z", "Y", "X"],
-    ["T", "Y", "X", "C"],
-    ["T", "Z", "Y", "X", "C"],
+    ["Time", "Y", "X", "Channel"],
+    ["Time", "Z", "Y", "X", "Channel"],
 ]
 
 

--- a/src/napari_imagej/widgets/widget_utils.py
+++ b/src/napari_imagej/widgets/widget_utils.py
@@ -202,7 +202,9 @@ class DimsComboBox(QFrame):
         selected = self.selection_box.combo.itemData(index)
         # Guess dimension labels for the selection
         ndim = len(selected.data.shape)
-        if isinstance(selected, Image) and selected.rgb:
+        if (dims := getattr(selected.data, "dims", None)) is not None:
+            guess = dims
+        elif isinstance(selected, Image) and selected.rgb:
             guess = list(CONVENTIONAL_DIMS[ndim - 1])
             guess.append("Channel")
         else:

--- a/src/napari_imagej/widgets/widget_utils.py
+++ b/src/napari_imagej/widgets/widget_utils.py
@@ -31,6 +31,17 @@ from napari_imagej.utilities._module_utils import (
     info_for,
 )
 
+# Generally, Python libraries treat the dimensions i of an array with n
+# dimensions as the CONVENTIONAL_DIMS[n][i] axis
+CONVENTIONAL_DIMS = [
+    [],
+    ["X"],
+    ["Y", "X"],
+    ["Z", "Y", "X"],
+    ["Time", "Y", "X", "Channel"],
+    ["Time", "Z", "Y", "X", "Channel"],
+]
+
 
 def python_actions_for(
     result: "jc.SearchResult", output_signal: Signal, parent_widget: QWidget = None
@@ -168,16 +179,6 @@ class LayerComboBox(QWidget):
 class DimsComboBox(QFrame):
     """A QFrame used to map the axes of a Layer to dimension labels"""
 
-    # NB: Strings correspond to supported net.imagej.axis.Axes types
-    dims = [
-        [],
-        ["X"],
-        ["Y", "X"],
-        ["Z", "Y", "X"],
-        ["Time", "Y", "X", "Channel"],
-        ["Time", "Z", "Y", "X", "Channel"],
-    ]
-
     def __init__(self, combo_box: LayerComboBox):
         super().__init__()
         self.selection_box: LayerComboBox = combo_box
@@ -202,10 +203,10 @@ class DimsComboBox(QFrame):
         # Guess dimension labels for the selection
         ndim = len(selected.data.shape)
         if isinstance(selected, Image) and selected.rgb:
-            guess = list(self.dims[ndim - 1])
+            guess = list(CONVENTIONAL_DIMS[ndim - 1])
             guess.append("Channel")
         else:
-            guess = self.dims[ndim]
+            guess = CONVENTIONAL_DIMS[ndim]
         # Create dimension selectors for each dimension of the selection.
         for i, g in enumerate(guess):
             self.layout().addWidget(

--- a/tests/widgets/test_parameter_widgets.py
+++ b/tests/widgets/test_parameter_widgets.py
@@ -174,6 +174,23 @@ def test_mutable_output_add_new_image(
     assert foo is output_widget.value
 
 
+def test_mutable_output_add_new_image_dims_repeats(output_widget: MutableOutputWidget):
+    """Tests that MutableOutputWidget can add a new image from params"""
+
+    params = {
+        "name": "foo",
+        "array_type": "xarray",
+        "shape": ((100, "Y"), (100, "Y"), (3, "C")),
+        "fill_value": 3.0,
+        "data_type": np.int32,
+    }
+
+    with pytest.raises(ValueError):
+        output_widget._add_new_image(params)
+
+    assert "foo" not in current_viewer().layers
+
+
 def test_numbers(ij):
     numbers = [
         jc.Byte,

--- a/tests/widgets/test_parameter_widgets.py
+++ b/tests/widgets/test_parameter_widgets.py
@@ -20,6 +20,7 @@ from magicgui.widgets import (
 from napari import current_viewer
 from napari.layers import Image
 from scyjava import numeric_bounds
+from xarray import DataArray
 
 from napari_imagej.widgets.parameter_widgets import (
     DirectoryWidget,
@@ -98,17 +99,27 @@ def test_mutable_output_default_parameters(
 
     # Assert when no selection, output shape is default
     assert input_widget.current_choice == ""
-    assert output_widget._default_new_shape() == [512, 512]
+    assert output_widget._default_new_shape() == [(512, "Y"), (512, "X")]
     assert output_widget._default_new_type() == "float64"
 
-    # Add new image
+    # Add new Z-stack
+    shape = (3, 128, 128)
+    import numpy as np
+
+    current_viewer().add_image(data=np.ones(shape, dtype=np.int32), name="Z")
+    assert input_widget.current_choice == "Z"
+    assert output_widget._default_new_shape() == [(3, "Z"), (128, "Y"), (128, "X")]
+    assert output_widget._default_new_type() == "int32"
+
+    # Add new RGB image
     shape = (128, 128, 3)
     import numpy as np
 
-    current_viewer().add_image(data=np.ones(shape, dtype=np.int32), name="img")
-    assert input_widget.current_choice == "img"
-    assert output_widget._default_new_shape() == shape
-    assert output_widget._default_new_type() == "int32"
+    current_viewer().layers.clear()
+    current_viewer().add_image(data=np.ones(shape, dtype=np.int16), name="RGB")
+    assert input_widget.current_choice == "RGB"
+    assert output_widget._default_new_shape() == [(128, "Y"), (128, "X"), (3, "C")]
+    assert output_widget._default_new_type() == "int16"
 
 
 def test_mutable_output_dtype_choices(
@@ -126,16 +137,13 @@ def test_mutable_output_dtype_choices(
 # these types are always included
 backing_types = [
     ("NumPy", np.ndarray),
+    ("xarray", DataArray),
 ]
 # these types are sometimes included
 if importlib.util.find_spec("zarr"):
     from zarr.core import Array
 
     backing_types.append(("Zarr", Array))
-if importlib.util.find_spec("xarray"):
-    from xarray import DataArray
-
-    backing_types.append(("xarray", DataArray))
 
 
 @pytest.mark.parametrize(argnames=["choice", "type"], argvalues=backing_types)
@@ -147,7 +155,7 @@ def test_mutable_output_add_new_image(
     params = {
         "name": "foo",
         "array_type": choice,
-        "shape": (100, 100, 3),
+        "shape": ((100, "Y"), (100, "X"), (3, "C")),
         "fill_value": 3.0,
         "data_type": np.int32,
     }


### PR DESCRIPTION
This PR overhauls the "New" button for creating preallocated outputs. Currently, two changes have been made:
* `xarray` is now the default data structure.
* Axis types can be provided for each dimension.

![image](https://github.com/user-attachments/assets/070aa29b-66fc-4bbc-824e-37c1fd064f7a)

This PR is currently a draft because it is incomplete, and needs further cleanup.

Closes #277