### PR TITLE
Use QElidingLabel instead of QLabel

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -31,6 +31,7 @@ dependencies:
   - pandas
   - pyimagej >= 1.4.1
   - scyjava >= 1.8.1
+  - superqt >= 0.7.0
   - xarray < 2024.10.0
   # Version rules to avoid problems
   - qtconsole != 5.4.2

--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,7 @@ dependencies:
   - pandas
   - pyimagej >= 1.4.1
   - scyjava >= 1.8.1
+  - superqt >= 0.7.0
   - xarray < 2024.10.0
   # Version rules to avoid problems
   - qtconsole != 5.4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pandas",
     "pyimagej >= 1.4.1",
     "scyjava >= 1.9.1",
+    "superqt >= 0.7.0",
     "xarray < 2024.10.0",
     # Version rules to avoid problems
     "qtconsole != 5.4.2", # https://github.com/napari/napari/issues/5700

--- a/src/napari_imagej/widgets/parameter_widgets.py
+++ b/src/napari_imagej/widgets/parameter_widgets.py
@@ -460,36 +460,6 @@ class MutableOutputWidget(Container):
         """
         self.layer_select.reset_choices()
 
-    @property
-    def current_choice(self) -> str:
-        """Return the text of the currently selected choice."""
-        return self.layer_select.current_choice
-
-    def __len__(self) -> int:
-        """Return the number of choices."""
-        return self.layer_select.__len__()
-
-    def get_choice(self, choice_name: str):
-        """Get data for the provided ``choice_name``."""
-        return self.layer_select.get_choice(choice_name)
-
-    def set_choice(self, choice_name: str, data: Any = None):
-        """Set data for the provided ``choice_name``."""
-        return self.layer_select.set_choice(choice_name, data)
-
-    def del_choice(self, choice_name: str):
-        """Delete the provided ``choice_name`` and associated data."""
-        return self.layer_select.del_choice(choice_name)
-
-    @property
-    def choices(self):
-        """Available value choices for this widget."""
-        return self.layer_select.choices
-
-    @choices.setter
-    def choices(self, choices: ChoicesType):
-        self.layer_select.choices = choices
-
 
 # -- FILE WIDGETS -- #
 

--- a/src/napari_imagej/widgets/result_runner.py
+++ b/src/napari_imagej/widgets/result_runner.py
@@ -9,7 +9,8 @@ from typing import Callable, Dict, List, Union
 
 from napari import Viewer
 from qtpy.QtCore import Qt, Signal
-from qtpy.QtWidgets import QApplication, QLabel, QPushButton, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QApplication, QPushButton, QVBoxLayout, QWidget
+from superqt import QElidingLabel
 
 from napari_imagej.java import jc
 from napari_imagej.widgets.layouts import QFlowLayout
@@ -46,7 +47,7 @@ class ResultRunner(QWidget):
 
         self.setLayout(QVBoxLayout())
 
-        self.selected_module_label = QLabel()
+        self.selected_module_label = QElidingLabel()
         self.layout().addWidget(self.selected_module_label)
         self.button_pane = QWidget()
         self.button_pane.setLayout(QFlowLayout())

--- a/tests/widgets/test_parameter_widgets.py
+++ b/tests/widgets/test_parameter_widgets.py
@@ -74,20 +74,25 @@ def input_widget(mutable_output_widget):
     return widget
 
 
-def test_mutable_output_widget_layout(output_widget):
-    children = [w for w in output_widget]
-    assert len(children) == 2
-    assert isinstance(children[0], PushButton)
-    assert isinstance(children[1], ComboBox)
-    assert children[0].tooltip == "Create a new output container"
-    assert children[0].max_width == 53
-    assert (
-        children[1].tooltip
-        == "Optional - produces a new layer unless an output container is provided"
-    )
-    assert output_widget.current_choice == ""
+def test_mutable_output_widget_layout(output_widget: MutableOutputWidget):
+    assert output_widget.value is None
     assert output_widget.layout == "horizontal"
     assert output_widget.margins == (0, 0, 0, 0)
+
+    children = [w for w in output_widget]
+    assert len(children) == 2
+
+    assert isinstance(children[0], ComboBox)
+    assert (
+        children[0].tooltip
+        == "Optional - produces a new layer unless an output container is provided"
+    )
+    # Current value is None - text should be empty
+    assert children[0].current_choice == ""
+
+    assert isinstance(children[1], PushButton)
+    assert children[1].tooltip == "Create a new output container"
+    assert children[1].max_width == 53
 
 
 def test_mutable_output_default_parameters(
@@ -171,7 +176,7 @@ def test_mutable_output_add_new_image(
     assert (3) == np.unique(foo.data)
 
     assert foo in input_widget.choices
-    assert foo in output_widget.choices
+    assert foo in output_widget.layer_select.choices
     assert foo is output_widget.value
 
 

--- a/tests/widgets/test_result_runner.py
+++ b/tests/widgets/test_result_runner.py
@@ -2,9 +2,12 @@
 A module testing napari_imagej.widgets.result_runner
 """
 
+from __future__ import annotations
+
 import pytest
-from qtpy.QtWidgets import QLabel, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QVBoxLayout, QWidget
 from scyjava import JavaClasses
+from superqt import QElidingLabel
 
 from napari_imagej.widgets.layouts import QFlowLayout
 from napari_imagej.widgets.result_runner import ResultRunner
@@ -32,10 +35,27 @@ def test_result_runner(result_runner):
     # The layout
     assert isinstance(subwidgets[0], QVBoxLayout)
     # The label describing the selected module
-    assert isinstance(subwidgets[1], QLabel)
+    assert isinstance(subwidgets[1], QElidingLabel)
     # The button Container
     assert isinstance(subwidgets[2], QWidget)
     assert isinstance(subwidgets[2].layout(), QFlowLayout)
+
+
+def test_result_runner_size_hints(result_runner: ResultRunner):
+    """Ensuring the widget doesn't grow when text is set."""
+    # The problem we want to safeguard against here is ensuring the minimum
+    # size hint doesn't change - this is what causes issues like
+    # https://github.com/imagej/napari-imagej/issues/273
+
+    # Capture size hint
+    hint = result_runner.minimumSizeHint()
+    width_hint, height_hint = hint.width(), hint.height()
+    # Resize result_runner
+    result_runner._setText("o" * 50)
+    # Assert size hint did not change
+    hint = result_runner.minimumSizeHint()
+    assert width_hint == hint.width()
+    assert height_hint == hint.height()
 
 
 @pytest.fixture


### PR DESCRIPTION
napari depends on superqt, so we are only adding a new dependency in writing.

Note that this will require the merge and release of pyapp-kit/superqt#260 to work properly

Closes #273