### PR TITLE
Add menu path to search results

### DIFF
--- a/src/napari_imagej/widgets/result_tree.py
+++ b/src/napari_imagej/widgets/result_tree.py
@@ -7,7 +7,7 @@ SearchResults are grouped by the SciJava Searcher that created them.
 from __future__ import annotations
 
 from logging import getLogger
-from typing import Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from qtpy.QtCore import QRectF, Qt, Signal, QSize
 from qtpy.QtGui import QStandardItem, QStandardItemModel, QTextDocument
@@ -28,9 +28,10 @@ from napari_imagej.widgets.widget_utils import _get_icon, python_actions_for
 if TYPE_CHECKING:
     from qtpy.QtCore import QModelIndex
 
+    from typing import Dict, List
 
-# FIXME: Ideally we'd use something from the palette
-# but there's no good options
+
+# Color used for additional information in the QTreeView
 HIGHLIGHT = "#8C745E"
 
 
@@ -155,13 +156,13 @@ class HTMLItemDelegate(QStyledItemDelegate):
         doc.setHtml(rich_text)
 
         painter.save()
-        painter.setClipRect(options.rect)
-
-        # NB: Unsure why we can't pass subElementRect output to drawContents...
+        # Translate the painter to the correct item
+        # NB offset is necessary to account for checkbox, icon
         text_offset = style.subElementRect(
             QStyle.SE_ItemViewItemText, options, options.widget
         ).x()
         painter.translate(text_offset, options.rect.top())
+        # Paint the rich text
         rect = QRectF(0, 0, options.rect.width(), options.rect.height())
         doc.drawContents(painter, rect)
 
@@ -171,6 +172,7 @@ class HTMLItemDelegate(QStyledItemDelegate):
         options = QStyleOptionViewItem(option)
         self.initStyleOption(options, index)
 
+        # size hint is the size of the rendered HTML
         doc = QTextDocument()
         doc.setHtml(options.text)
         doc.setTextWidth(options.rect.width())
@@ -251,6 +253,7 @@ class SearchResultModel(QStandardItemModel):
         if isinstance(item, SearcherItem):
             if item.hasChildren():
                 item.setData(
+                    # Write the number of results in "highlight text"
                     f'{item.searcher.title()} <span style="color:{HIGHLIGHT};">({item.rowCount()})</span>',
                     Qt.DisplayRole,
                 )

--- a/src/napari_imagej/widgets/widget_utils.py
+++ b/src/napari_imagej/widgets/widget_utils.py
@@ -3,6 +3,7 @@ from logging import getLogger
 from typing import List
 
 from jpype import JArray, JByte
+from scyjava import jvm_started
 from magicgui import magicgui
 from napari import Viewer
 from napari.layers import Image, Labels, Layer, Points, Shapes
@@ -315,7 +316,8 @@ def _get_icon(path: str, cls: "jc.Class" = None):
         # TODO: Add icons from web
         return
     # Java Resources
-    elif isinstance(cls, jc.Class):
+    # NB: Use java only if JVM started
+    elif jvm_started() and isinstance(cls, jc.Class):
         stream = cls.getResourceAsStream(path)
         # Ignore falsy streams
         if not stream:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,12 +2,17 @@
 A module containing testing utilities
 """
 
-from typing import List
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from jpype import JImplements, JOverride
 from scyjava import JavaClasses
 
 from napari_imagej.java import NijJavaClasses
+
+if TYPE_CHECKING:
+    from typing import Dict, List
 
 
 class JavaClassesTest(NijJavaClasses):
@@ -170,8 +175,9 @@ class DummySearchEvent:
 
 
 class DummySearchResult(object):
-    def __init__(self, info: "jc.ModuleInfo" = None):
+    def __init__(self, info: "jc.ModuleInfo" = None, properties: Dict = {}):
         self._info = info
+        self._properties = properties
 
     def name(self):
         return "This is not a Search Result"
@@ -184,6 +190,12 @@ class DummySearchResult(object):
 
     def getClass(self):
         return None
+
+    def properties(self):
+        return self._properties
+
+    def set_properties(self, props: Dict):
+        self._properties = props
 
 
 class DummyModuleInfo:

--- a/tests/widgets/test_result_tree.py
+++ b/tests/widgets/test_result_tree.py
@@ -49,11 +49,17 @@ def test_searchers_persist(fixed_tree: SearcherTreeView, asserter):
     asserter(lambda: fixed_tree.model().invisibleRootItem().rowCount() == 2)
 
 
-def test_resultTreeItem_regression():
+def test_resultTreeItem_regression(ij):
     dummy = DummySearchResult()
     item = SearchResultItem(dummy)
     assert item.result == dummy
     assert item.data(0) == dummy.name()
+
+    dummy = DummySearchResult(properties={"Menu path": "foo > bar > baz"})
+    item = SearchResultItem(dummy)
+    assert item.result == dummy
+    data = f'{dummy.name()} <span style="color:#8C745E;">foo > bar > baz</span>'
+    assert item.data(0) == data
 
 
 def test_searcherTreeItem_regression():
@@ -87,7 +93,8 @@ def test_search_tree_disable(fixed_tree: SearcherTreeView, asserter):
     # Grab an arbitratry enabled Searcher
     item = fixed_tree.model().invisibleRootItem().child(1, 0)
     # Assert GUI start
-    asserter(lambda: item.data(0) == "Test2 (3)")
+    data = 'Test2 <span style="color:#8C745E;">(3)</span>'
+    asserter(lambda: item.data(0) == data)
     asserter(lambda: item.checkState() == Qt.Checked)
 
     # Disable the searcher, assert the proper GUI response

--- a/tests/widgets/test_result_tree.py
+++ b/tests/widgets/test_result_tree.py
@@ -6,7 +6,7 @@ import pytest
 from qtpy.QtCore import QRunnable, Qt, QThreadPool
 from qtpy.QtWidgets import QApplication, QMenu
 
-from napari_imagej.java import init_ij
+from napari_imagej import nij
 from napari_imagej.widgets.result_tree import (
     SearcherItem,
     SearcherTreeView,
@@ -23,7 +23,7 @@ def results_tree():
 
 
 @pytest.fixture
-def fixed_tree(ij, asserter):
+def fixed_tree(asserter):
     """Creates a "fake" ResultsTree with deterministic results"""
     # Create a default SearchResultTree
     tree = SearcherTreeView(None)
@@ -49,7 +49,12 @@ def test_searchers_persist(fixed_tree: SearcherTreeView, asserter):
     asserter(lambda: fixed_tree.model().invisibleRootItem().rowCount() == 2)
 
 
-def test_resultTreeItem_regression(ij):
+def test_regression():
+    """Tests SearchResultItems, SearcherItems display as expected."""
+    # SearchResultItems wrap SciJava SearchResults, so they expect a running JVM
+    nij.ij
+
+    # Phase 1: Search Results
     dummy = DummySearchResult()
     item = SearchResultItem(dummy)
     assert item.result == dummy
@@ -61,9 +66,7 @@ def test_resultTreeItem_regression(ij):
     data = f'{dummy.name()} <span style="color:#8C745E;">foo > bar > baz</span>'
     assert item.data(0) == data
 
-
-def test_searcherTreeItem_regression():
-    init_ij()
+    # Phase 2: Searchers
     dummy = DummySearcher("This is not a Searcher")
     item = SearcherItem(dummy)
     assert item.searcher == dummy
@@ -78,7 +81,7 @@ def test_searcherTreeItem_regression():
     assert item.data(0) == dummy.title()
 
 
-def test_key_return_expansion(fixed_tree: SearcherTreeView, qtbot, asserter):
+def test_key_return_expansion(fixed_tree: SearcherTreeView, qtbot):
     idx = fixed_tree.model().index(0, 0)
     fixed_tree.setCurrentIndex(idx)
     expanded = fixed_tree.isExpanded(idx)

--- a/tests/widgets/widget_utils.py
+++ b/tests/widgets/widget_utils.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from qtpy.QtCore import Qt
 
+from napari_imagej import nij
 from napari_imagej.widgets.result_tree import SearcherItem, SearcherTreeView
 from tests.utils import DummySearcher, DummySearchEvent, jc
 
@@ -19,6 +20,9 @@ def _searcher_tree_named(tree: SearcherTreeView, name: str) -> Optional[Searcher
 
 
 def _populate_tree(tree: SearcherTreeView, asserter):
+    # DummySearchers are SciJava Searchers - we need a JVM
+    nij.ij
+
     root = tree.model().invisibleRootItem()
     asserter(lambda: root.rowCount() == 0)
     # Add two searchers

--- a/tests/widgets/widget_utils.py
+++ b/tests/widgets/widget_utils.py
@@ -44,7 +44,12 @@ def _populate_tree(tree: SearcherTreeView, asserter):
     )
 
     # Wait for the tree to populate
-    asserter(lambda: root.child(0, 0).rowCount() == 2)
-    asserter(lambda: root.child(0, 0).data(0) == "Test1 (2)")
-    asserter(lambda: root.child(1, 0).rowCount() == 3)
-    asserter(lambda: root.child(1, 0).data(0) == "Test2 (3)")
+    count = 2
+    asserter(lambda: root.child(0, 0).rowCount() == count)
+    data = f'Test1 <span style="color:#8C745E;">({count})</span>'
+    asserter(lambda: root.child(0, 0).data(0) == data)
+
+    count = 3
+    asserter(lambda: root.child(1, 0).rowCount() == count)
+    data = f'Test2 <span style="color:#8C745E;">({count})</span>'
+    asserter(lambda: root.child(1, 0).data(0) == data)


### PR DESCRIPTION
This PR adds ability to render HTML in our `QSearcherTreeView` showing search results, enabling display of the menu path for each relevant search result. I similarly colored the number of search results for each `Searcher`.

TODO:
* [ ] Add tests
* [ ] Ensure the [`QPalette`](https://doc.qt.io/qt-6/qpalette.html) doesn't have a suitable color for the "highlight". I didn't find one, and the current color (stolen from the SciJava "Quick Search" menu) works well for dark and light backgrounds.
* [ ] Update documentation?

Closes #271

![image](https://github.com/user-attachments/assets/1de9dc7f-ba1f-42b4-9f57-fc7a27fb6d3c)
