### PR TITLE
Detach initialization QThread after ImageJ initialized

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,12 @@ env:
 
 jobs:
   test-pip:
-    name: ${{ matrix.platform }} py${{ matrix.python-version }}
+    name: ${{ matrix.platform }} (python ${{ matrix.python-version }})
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.12']
+        python-version: ['3.9', '3.12']
 
     steps:
       - uses: actions/checkout@v2

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -18,7 +18,7 @@ name: napari-imagej-dev
 channels:
   - conda-forge
 dependencies:
-  - python >= 3.8, < 3.13
+  - python >= 3.9, < 3.13
   # Project dependencies
   - confuse >= 2.0.0
   - imglyb >= 2.1.0

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ name: napari-imagej
 channels:
   - conda-forge
 dependencies:
-  - python >= 3.8, < 3.13
+  - python >= 3.9, < 3.13
   # Project depenencies
   - confuse >= 2.0.0
   - imglyb >= 2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Framework :: napari",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: Unix",
     "Operating System :: MacOS",
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 # NB: Keep this in sync with environment.yml AND dev-environment.yml!
-requires-python = ">=3.8, <3.13"
+requires-python = ">=3.9, <3.13"
 dependencies = [
     "confuse >= 2.0.0",
     "imglyb >= 2.1.0",

--- a/src/napari_imagej/java.py
+++ b/src/napari_imagej/java.py
@@ -311,6 +311,10 @@ class NijJavaClasses(JavaClasses):
         return "java.nio.file.Path"
 
     @JavaClasses.java_import
+    def Thread(self):
+        return "java.lang.Thread"
+
+    @JavaClasses.java_import
     def Window(self):
         return "java.awt.Window"
 


### PR DESCRIPTION
JPype automatically attaches all threads accessing Java, but when we dynamically allocate a thread (as we do during initialization) we need to manually detach it. 

Closes #307 