### PR TITLE
Improve labels transfer to ImageJ

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - numpy
   - openjdk=11
   - pandas
-  - pyimagej >= 1.4.1
+  - pyimagej >= 1.5.0
   - scyjava >= 1.9.1
   - superqt >= 0.7.0
   - xarray < 2024.10.0

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - numpy
   - openjdk=11
   - pandas
-  - pyimagej >= 1.4.1
+  - pyimagej >= 1.5.0
   - scyjava >= 1.9.1
   - superqt >= 0.7.0
   - xarray < 2024.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "napari >= 0.4.17",
     "numpy",
     "pandas",
-    "pyimagej >= 1.4.1",
+    "pyimagej >= 1.5.0",
     "scyjava >= 1.9.1",
     "superqt >= 0.7.0",
     "xarray < 2024.10.0",

--- a/src/napari_imagej/widgets/widget_utils.py
+++ b/src/napari_imagej/widgets/widget_utils.py
@@ -301,7 +301,8 @@ class DetailExportDialog(QDialog):
             )
             # Labels layers should display the index image
             if isinstance(j_img, jc.ImgLabeling):
-                j_img = j_img.getIndexImg()
+                j_img = nij.ij.py.to_dataset(j_img.getIndexImg())
+                j_img.setName(img.name)
             if roi:
                 if isinstance(roi, Points):
                     j_point = nij.ij.py.to_java(roi)


### PR DESCRIPTION
This PR provides the ability to transfer napari `Labels` to the ImageJ UI. Notably, it provides two different pathways:
1. **As the image**: When a `Labels` layer is provided as the image, napari-imagej will convert the `Labels` layer to an `ImgLabeling`, and then will display the index image.
2. **As rois**: When a `Labels` layer is provided as the rois, napari-imagej will convert the `Labels` layer to `ROITree` (using @elevans' wonderful work in imagej/pyimagej#283), then attached and displayed as ROIs. Note that this pathway required the bump in the pyimagej min version.

You can see the results in the image below, where I:

1. Loaded in the `brick` sample image in napari
2. Manually annotated two labels on a new Layer
4. Using the detailed image transfer button, transferred the `Labels` as an image to get `(V)` in the bottom left corner
5. Using the detailed image transfer button, transferred `brick` as an image *and `Labels` as rois* to get `brick (V)` in the bottom right corner.

![image](https://github.com/user-attachments/assets/2a41e54d-4908-4c58-8902-a6638c2c68b0)

### Concerns

**Working around imagej-common**: Arguably imagej-common (maybe [here](https://github.com/imagej/imagej-common/blob/be49499c377e42dc651ec7456a55a00ff29d2903/src/main/java/net/imagej/display/DefaultImageDisplay.java#L244)) and/or imagej-legacy should shoulder the burden of correctly displaying `ImgLabeling`s. I decided to avoid an implementation there because (a) it would take longer to be usable from napari-imagej and (b) I had a feeling the changes could be involved. @hinerm thoughts on this?

Closes #321 (cc @ian-coccimiglio)