### PR TITLE
Update citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ Distributed under the terms of the [BSD-2] license,
 
 ## Citing
 
-_napari-imagej: ImageJ ecosystem access from napari_, Nature Methods, 2023 Aug 18
-
-DOI: [10.1038/s41592-023-01990-0](https://doi.org/10.1038/s41592-023-01990-0)
+    Selzer, G.J., Rueden, C.T., Hiner, M.C. *et al.* napari-imagej: ImageJ ecosystem access from napari. *Nat Methods* **20**, 1443–1444 (2023). https://doi.org/10.1038/s41592-023-01990-0
 
 [Apache Software License 2.0]: https://www.apache.org/licenses/LICENSE-2.0
 [black]: https://github.com/psf/black

--- a/doc/Citation.rst
+++ b/doc/Citation.rst
@@ -1,0 +1,24 @@
+Citation
+========
+
+If you use napari-imagej in your work, please cite our paper:
+
+    Selzer, G.J., Rueden, C.T., Hiner, M.C. *et al.* napari-imagej: ImageJ ecosystem access from napari. *Nat Methods* **20**, 1443–1444 (2023). https://doi.org/10.1038/s41592-023-01990-0
+
+BibTeX:
+
+.. code-block:: bibtex
+
+    @article{Selzer_Rueden_Hiner_Evans_Harrington_Eliceiri_2023,
+      title={Napari-imagej: Imagej ecosystem access from Napari},
+      volume={20},
+      DOI={10.1038/s41592-023-01990-0},
+      number={10},
+      journal={Nature Methods},
+      author={Selzer, Gabriel J. and Rueden, Curtis T. and Hiner, Mark C. and Evans, Edward L. and Harrington, Kyle I. and Eliceiri, Kevin W.},
+      year={2023},
+      month={Aug},
+      pages={1443–1444}
+    } 
+
+If you have questions about citation or usage, please contact the project maintainers.

--- a/doc/Development.rst
+++ b/doc/Development.rst
@@ -45,7 +45,7 @@ Once you've made your changes, run the following:
 
 .. code-block:: bash
 
-    make docs
+    make html
 
 This will build the documentation into HTML files locally, stored in the ``doc/_build/html`` folder. You can then view the documentation locally by loading ``doc/_build/html/index.html`` in the browser of your choice.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,3 +37,5 @@ napari-imagej handles the burden of data transfer between these two applications
    Architecture
 
    Benchmarking
+
+   Citation


### PR DESCRIPTION
Added a small `Citation.rst` page describing how to cite the paper. Also updated the citation to match the [Nature methods website](https://www.nature.com/articles/s41592-023-01990-0#article-info)

Also a small dev guide fix.

@hinerm do you like this separate RTD page? Could also just put this on `index.rst`, right under the image...